### PR TITLE
All units should be able to receive certificates

### DIFF
--- a/lib/charms/tls_certificates_interface/v0/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v0/tls_certificates.py
@@ -323,10 +323,10 @@ class TLSCertificatesProvides(Object):
         """
         relation_data = _load_relation_data(event.relation.data[event.unit])
         if not relation_data:
-            logger.info("No relation data - Deferring")
+            logger.info("No relation data")
             return
         if not self._relation_data_is_valid(relation_data):
-            logger.warning("Relation data did not pass JSON Schema validation - Deferring")
+            logger.warning("Relation data did not pass JSON Schema validation")
             return
         for server_cert_request in relation_data.get("cert_requests", {}):
             self.on.certificate_request.emit(
@@ -459,9 +459,11 @@ class TLSCertificatesRequires(Object):
             None
         """
         relation_data = _load_relation_data(event.relation.data[event.unit])
+        if not relation_data:
+            logger.info("No relation data")
+            return
         if not self._relation_data_is_valid(relation_data):
-            logger.warning("Relation data did not pass JSON Schema validation - Deferring")
-            event.defer()
+            logger.warning("Relation data did not pass JSON Schema validation")
             return
 
         certificates = self._parse_certificates_from_relation_data(relation_data)

--- a/lib/charms/tls_certificates_interface/v0/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v0/tls_certificates.py
@@ -458,13 +458,12 @@ class TLSCertificatesRequires(Object):
         Returns:
             None
         """
-        if self.model.unit.is_leader():
-            relation_data = _load_relation_data(event.relation.data[event.unit])
-            if not self._relation_data_is_valid(relation_data):
-                logger.warning("Relation data did not pass JSON Schema validation - Deferring")
-                event.defer()
-                return
+        relation_data = _load_relation_data(event.relation.data[event.unit])
+        if not self._relation_data_is_valid(relation_data):
+            logger.warning("Relation data did not pass JSON Schema validation - Deferring")
+            event.defer()
+            return
 
-            certificates = self._parse_certificates_from_relation_data(relation_data)
-            for certificate in certificates:
-                self.on.certificate_available.emit(certificate_data=certificate)
+        certificates = self._parse_certificates_from_relation_data(relation_data)
+        for certificate in certificates:
+            self.on.certificate_available.emit(certificate_data=certificate)

--- a/tests/charms/tls_certificates_interface/v0/test_tls_certificates.py
+++ b/tests/charms/tls_certificates_interface/v0/test_tls_certificates.py
@@ -18,13 +18,21 @@ REQUIRER_UNIT_NAME = "whatever requirer unit name"
 CHARM_LIB_PATH = "charms.tls_certificates_interface.v0.tls_certificates"
 
 
-class UnitMock:
+class LeaderUnitMock:
     def __init__(self, name):
         self.name = name
 
     @staticmethod
     def is_leader():
         return True
+
+class NonLeaderUnitMock:
+    def __init__(self, name):
+        self.name = name
+
+    @staticmethod
+    def is_leader():
+        return False
 
 
 def _load_relation_data(raw_relation_data: dict) -> dict:
@@ -50,8 +58,8 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             charm=charm, relationship_name=relationship_name
         )
         self.charm = charm
-        self.provider_unit = UnitMock(name=PROVIDER_UNIT_NAME)
-        self.requirer_unit = UnitMock(name=REQUIRER_UNIT_NAME)
+        self.provider_unit = LeaderUnitMock(name=PROVIDER_UNIT_NAME)
+        self.requirer_unit = NonLeaderUnitMock(name=REQUIRER_UNIT_NAME)
         self.charm.framework.model.unit = self.provider_unit
 
     @patch(
@@ -235,8 +243,8 @@ class TestTLSCertificatesRequires(unittest.TestCase):
             charm=charm, relationship_name=relationship_name
         )
         self.charm = charm
-        self.provider_unit = UnitMock(name=PROVIDER_UNIT_NAME)
-        self.requirer_unit = UnitMock(name=REQUIRER_UNIT_NAME)
+        self.provider_unit = LeaderUnitMock(name=PROVIDER_UNIT_NAME)
+        self.requirer_unit = NonLeaderUnitMock(name=REQUIRER_UNIT_NAME)
         self.charm.framework.model.unit = self.requirer_unit
 
     def test_given_client_when_request_certificate_then_client_cert_request_is_added_to_relation_data(  # noqa: E501

--- a/tests/charms/tls_certificates_interface/v0/test_tls_certificates.py
+++ b/tests/charms/tls_certificates_interface/v0/test_tls_certificates.py
@@ -298,7 +298,7 @@ class TestTLSCertificatesRequires(unittest.TestCase):
         f"{CHARM_LIB_PATH}.CertificatesRequirerCharmEvents.certificate_available",
         new_callable=PropertyMock,
     )
-    def test_given_valid_relation_data_when_on_relation_changed_and_unit_is_not_leader_then_certificate_available_event_is_emitted(  # noqa: E501
+    def test_given_valid_relation_data_and_unit_is_not_leader_when_on_relation_changed_then_certificate_available_event_is_emitted(  # noqa: E501
         self, patch_emit
     ):
         event = Mock()
@@ -332,7 +332,7 @@ class TestTLSCertificatesRequires(unittest.TestCase):
         f"{CHARM_LIB_PATH}.CertificatesRequirerCharmEvents.certificate_available",
         new_callable=PropertyMock,
     )
-    def test_given_valid_relation_data_when_on_relation_changed_and_unit_is_leader_then_certificate_available_event_is_emitted(  # noqa: E501
+    def test_given_valid_relation_data_and_unit_is_leader_when_on_relation_changed_then_certificate_available_event_is_emitted(  # noqa: E501
         self, patch_emit
     ):
         event = Mock()

--- a/tests/charms/tls_certificates_interface/v0/test_tls_certificates.py
+++ b/tests/charms/tls_certificates_interface/v0/test_tls_certificates.py
@@ -278,7 +278,13 @@ class TestTLSCertificatesRequires(unittest.TestCase):
                 cert_type="client", common_name="whatever common name"
             )
 
-    def test_given_non_valid_relation_data_when_on_relation_changed_then_event_is_deferred(self):
+    @patch(
+        f"{CHARM_LIB_PATH}.CertificatesRequirerCharmEvents.certificate_available",
+        new_callable=PropertyMock,
+    )
+    def test_given_non_valid_relation_data_when_on_relation_changed_then_certificate_available_event_is_not_emitted(
+        self, patch_emit
+    ):
         event = Mock()
         bad_relation_data = [
             {
@@ -292,7 +298,7 @@ class TestTLSCertificatesRequires(unittest.TestCase):
         event.unit = self.provider_unit
         self.tls_certificate_requires._on_relation_changed(event)
 
-        self.assertTrue(event.defer.call_count == 1)
+        patch_emit.assert_not_called()
 
     @patch(
         f"{CHARM_LIB_PATH}.CertificatesRequirerCharmEvents.certificate_available",

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins
@@ -57,6 +57,8 @@ deps =
     juju
     types-setuptools
     types-toml
+setenv =
+    PYTHONPATH = ""
 commands =
     mypy {[vars]all_path} {posargs}
 


### PR DESCRIPTION
This fixes linting and static analysis in PR #2 and also add a new tests. This is based on @delgod's PR. We need this functionality in charmed-magma to properly support scaling.