### PR TITLE
Add revoke_all_certificates to ProviderV1

### DIFF
--- a/lib/charms/tls_certificates_interface/v1/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v1/tls_certificates.py
@@ -240,7 +240,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 REQUIRER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -827,6 +827,14 @@ class TLSCertificatesProvidesV1(Object):
             return True
         except exceptions.ValidationError:
             return False
+
+    def revoke_all_certificates(self) -> None:
+        """Revokes all certificates of this provider.
+
+        This method is meant to be used when the Root CA has changed.
+        """
+        for relation in self.model.relations[self.relationship_name]:
+            relation.data[self.model.app]["certificates"] = json.dumps([])
 
     def set_relation_certificate(
         self,

--- a/lib/charms/tls_certificates_interface/v1/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v1/tls_certificates.py
@@ -903,6 +903,7 @@ class TLSCertificatesProvidesV1(Object):
         Returns:
             None
         """
+        assert event.unit is not None
         requirer_relation_data = _load_relation_data(event.relation.data[event.unit])
         provider_relation_data = _load_relation_data(event.relation.data[self.charm.app])
         if not self._relation_data_is_valid(requirer_relation_data):
@@ -1154,7 +1155,7 @@ class TLSCertificatesRequiresV1(Object):
         if not self._relation_data_is_valid(provider_relation_data):
             logger.warning(
                 f"Provider relation data did not pass JSON Schema validation: "
-                f"{event.relation.data[event.app]}"
+                f"{event.relation.data[relation.app]}"
             )
             return
         requirer_csrs = [

--- a/tests/integration/v1/test_integration.py
+++ b/tests/integration/v1/test_integration.py
@@ -28,10 +28,14 @@ class TestIntegration:
         TestIntegration.requirer_charm = await ops_test.build_charm(f"{REQUIRER_CHARM_DIR}/")
         TestIntegration.provider_charm = await ops_test.build_charm(f"{PROVIDER_CHARM_DIR}/")
         await ops_test.model.deploy(
-            TestIntegration.requirer_charm, application_name=TLS_CERTIFICATES_REQUIRER_APP_NAME
+            TestIntegration.requirer_charm,
+            application_name=TLS_CERTIFICATES_REQUIRER_APP_NAME,
+            series="focal",
         )
         await ops_test.model.deploy(
-            TestIntegration.provider_charm, application_name=TLS_CERTIFICATES_PROVIDER_APP_NAME
+            TestIntegration.provider_charm,
+            application_name=TLS_CERTIFICATES_PROVIDER_APP_NAME,
+            series="focal",
         )
 
         await ops_test.model.wait_for_idle(
@@ -70,7 +74,7 @@ class TestIntegration:
     ):
         new_requirer_app_name = "new-tls-requirer"
         await ops_test.model.deploy(
-            TestIntegration.requirer_charm, application_name=new_requirer_app_name
+            TestIntegration.requirer_charm, application_name=new_requirer_app_name, series="focal"
         )
         await ops_test.model.add_relation(
             relation1=new_requirer_app_name,

--- a/tests/unit/charms/tls_certificates_interface/v1/test_tls_certificates_v1_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v1/test_tls_certificates_v1_provides.py
@@ -645,5 +645,5 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         provider_relation_data = self.harness.get_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name
         )
-        provider_relation_data = _load_relation_data(dict(provider_relation_data))
+        provider_relation_data = _load_relation_data(provider_relation_data)
         self.assertEqual({"certificates": []}, provider_relation_data)

--- a/tests/unit/charms/tls_certificates_interface/v1/test_tls_certificates_v1_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v1/test_tls_certificates_v1_provides.py
@@ -614,3 +614,33 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         self.assertEqual(call_args_list[0].args[0].relation_id, relation_1_id)
         self.assertEqual(call_args_list[1].args[0].certificate_signing_request, csr_2)
         self.assertEqual(call_args_list[1].args[0].relation_id, relation_2_id)
+
+    def test_given_certificates_in_relation_data_when_revoke_all_certificates_then_no_certificates_are_present(  # noqa: e501
+        self,
+    ):
+        relation_id = self.create_certificates_relation_with_1_remote_unit()
+        self.harness.set_leader(is_leader=True)
+        certificate = "whatever cert"
+        key_values = {
+            "certificates": json.dumps(
+                [
+                    {
+                        "certificate_signing_request": "whatever csr",
+                        "certificate": certificate,
+                        "ca": "whatever ca",
+                        "chain": ["whatever cert 1", "whatever cert 2"],
+                    }
+                ]
+            )
+        }
+        self.harness.update_relation_data(
+            relation_id=relation_id, app_or_unit=self.harness.charm.app.name, key_values=key_values
+        )
+
+        self.harness.charm.certificates.revoke_all_certificates()
+
+        provider_relation_data = self.harness.get_relation_data(
+            relation_id=relation_id, app_or_unit=self.harness.charm.app.name
+        )
+        provider_relation_data = _load_relation_data(dict(provider_relation_data))
+        self.assertEqual({"certificates": []}, provider_relation_data)

--- a/tests/unit/charms/tls_certificates_interface/v1/test_tls_certificates_v1_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v1/test_tls_certificates_v1_provides.py
@@ -113,6 +113,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         self, patch_certificate_creation_request
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
+        self.harness.set_leader(is_leader=True)
         csr = "whatever csr"
         provider_app_data = {
             "certificates": json.dumps(
@@ -157,6 +158,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         self, patch_certificate_revocation_request, _
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
+        self.harness.set_leader(is_leader=True)
         certificate = "whatever cert"
         csr = "whatever csr"
         ca = "whatever ca"
@@ -203,6 +205,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         patch_remove_certificate,
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
+        self.harness.set_leader(is_leader=True)
         certificate = "whatever cert"
         self.harness.update_relation_data(
             relation_id=relation_id,

--- a/tests/unit/charms/tls_certificates_interface/v1/test_tls_certificates_v1_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v1/test_tls_certificates_v1_provides.py
@@ -647,3 +647,16 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         )
         provider_relation_data = _load_relation_data(provider_relation_data)
         self.assertEqual({"certificates": []}, provider_relation_data)
+
+    def test_given_no_certificates_in_relation_data_when_revoke_all_certificates_then_no_certificates_are_present(  # noqa: e501
+        self,
+    ):
+        relation_id = self.create_certificates_relation_with_1_remote_unit()
+        self.harness.set_leader(is_leader=True)
+        self.harness.charm.certificates.revoke_all_certificates()
+
+        provider_relation_data = self.harness.get_relation_data(
+            relation_id=relation_id, app_or_unit=self.harness.charm.app.name
+        )
+        provider_relation_data = _load_relation_data(provider_relation_data)
+        self.assertEqual({"certificates": []}, provider_relation_data)

--- a/tests/unit/charms/tls_certificates_interface/v1/test_tls_certificates_v1_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v1/test_tls_certificates_v1_requires.py
@@ -249,7 +249,7 @@ class Test(unittest.TestCase):
         csr = "whatever csr"
         certificate = "whatever certificate"
         unit_relation_data = {
-            "certificate_signing_requests": [{"certificate_signing_request": csr}]
+            "certificate_signing_requests": json.dumps([{"certificate_signing_request": csr}])
         }
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -257,14 +257,16 @@ class Test(unittest.TestCase):
             key_values=unit_relation_data,
         )
         remote_app_relation_data = {
-            "certificates": [
-                {
-                    "ca": ca_certificate,
-                    "chain": chain,
-                    "certificate_signing_request": csr,
-                    "certificate": certificate,
-                }
-            ]
+            "certificates": json.dumps(
+                [
+                    {
+                        "ca": ca_certificate,
+                        "chain": chain,
+                        "certificate_signing_request": csr,
+                        "certificate": certificate,
+                    }
+                ]
+            )
         }
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -291,14 +293,16 @@ class Test(unittest.TestCase):
         certificate = "whatever certificate"
 
         remote_app_relation_data = {
-            "certificates": [
-                {
-                    "ca": ca_certificate,
-                    "chain": chain,
-                    "certificate_signing_request": csr,
-                    "certificate": certificate,
-                }
-            ]
+            "certificates": json.dumps(
+                [
+                    {
+                        "ca": ca_certificate,
+                        "chain": chain,
+                        "certificate_signing_request": csr,
+                        "certificate": certificate,
+                    }
+                ]
+            )
         }
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -318,7 +322,7 @@ class Test(unittest.TestCase):
         csr = "whatever csr"
         certificate = "whatever certificate"
         unit_relation_data = {
-            "certificate_signing_requests": [{"certificate_signing_request": csr}]
+            "certificate_signing_requests": json.dumps([{"certificate_signing_request": csr}])
         }
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -326,13 +330,15 @@ class Test(unittest.TestCase):
             key_values=unit_relation_data,
         )
         remote_app_relation_data = {
-            "certificates": [
-                {
-                    "ca": ca_certificate,
-                    "chain": chain,
-                    "certificate": certificate,
-                }
-            ]
+            "certificates": json.dumps(
+                [
+                    {
+                        "ca": ca_certificate,
+                        "chain": chain,
+                        "certificate": certificate,
+                    }
+                ]
+            )
         }
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -369,14 +375,16 @@ class Test(unittest.TestCase):
         )
 
         remote_app_relation_data = {
-            "certificates": [
-                {
-                    "ca": ca_certificate.decode(),
-                    "chain": ["a", "b"],
-                    "certificate_signing_request": certificate_signing_request.decode(),
-                    "certificate": certificate.decode(),
-                }
-            ]
+            "certificates": json.dumps(
+                [
+                    {
+                        "ca": ca_certificate.decode(),
+                        "chain": ["a", "b"],
+                        "certificate_signing_request": certificate_signing_request.decode(),
+                        "certificate": certificate.decode(),
+                    }
+                ]
+            )
         }
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -418,14 +426,16 @@ class Test(unittest.TestCase):
         )
 
         remote_app_relation_data = {
-            "certificates": [
-                {
-                    "ca": ca_certificate.decode(),
-                    "chain": ["a", "b"],
-                    "certificate_signing_request": certificate_signing_request.decode(),
-                    "certificate": certificate.decode(),
-                }
-            ]
+            "certificates": json.dumps(
+                [
+                    {
+                        "ca": ca_certificate.decode(),
+                        "chain": ["a", "b"],
+                        "certificate_signing_request": certificate_signing_request.decode(),
+                        "certificate": certificate.decode(),
+                    }
+                ]
+            )
         }
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -464,14 +474,16 @@ class Test(unittest.TestCase):
         )
 
         remote_app_relation_data = {
-            "certificates": [
-                {
-                    "ca": ca_certificate.decode(),
-                    "chain": ["a", "b"],
-                    "certificate_signing_request": certificate_signing_request.decode(),
-                    "certificate": certificate.decode(),
-                }
-            ]
+            "certificates": json.dumps(
+                [
+                    {
+                        "ca": ca_certificate.decode(),
+                        "chain": ["a", "b"],
+                        "certificate_signing_request": certificate_signing_request.decode(),
+                        "certificate": certificate.decode(),
+                    }
+                ]
+            )
         }
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -519,14 +531,16 @@ class Test(unittest.TestCase):
         )
 
         remote_app_relation_data = {
-            "certificates": [
-                {
-                    "ca": ca_certificate.decode(),
-                    "chain": ["a", "b"],
-                    "certificate_signing_request": certificate_signing_request.decode(),
-                    "certificate": certificate.decode(),
-                }
-            ]
+            "certificates": json.dumps(
+                [
+                    {
+                        "ca": ca_certificate.decode(),
+                        "chain": ["a", "b"],
+                        "certificate_signing_request": certificate_signing_request.decode(),
+                        "certificate": certificate.decode(),
+                    }
+                ]
+            )
         }
         self.harness.update_relation_data(
             relation_id=relation_id,

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
# Description

This PR adds a `revoke_all_certificates` method to `TLSCertificatesProvidesV1`. This is intended to be called by the provider charm when the root CA has changed.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
