### PR TITLE
Only sets relation certificate when unit is leader

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1019,6 +1019,8 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             None
         """
+        if not self.model.unit.is_leader():
+            return
         certificates_relation = self.model.get_relation(
             relation_name=self.relationship_name, relation_id=relation_id
         )

--- a/tests/unit/charms/tls_certificates_interface/v2/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/dummy_provider_charm/src/charm.py
@@ -4,17 +4,17 @@
 from ops.charm import CharmBase
 from ops.main import main
 
-from lib.charms.tls_certificates_interface.v1.tls_certificates import (
+from lib.charms.tls_certificates_interface.v2.tls_certificates import (
     CertificateCreationRequestEvent,
     CertificateRevocationRequestEvent,
-    TLSCertificatesProvidesV1,
+    TLSCertificatesProvidesV2,
 )
 
 
 class DummyTLSCertificatesProviderCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.certificates = TLSCertificatesProvidesV1(self, "certificates")
+        self.certificates = TLSCertificatesProvidesV2(self, "certificates")
         self.framework.observe(
             self.certificates.on.certificate_creation_request,
             self._on_certificate_creation_request,

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2.py
@@ -5,7 +5,7 @@
 import uuid
 
 import pytest
-from charms.tls_certificates_interface.v1.tls_certificates import (
+from charms.tls_certificates_interface.v2.tls_certificates import (
     generate_ca,
     generate_certificate,
     generate_csr,
@@ -17,16 +17,16 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.serialization import load_pem_private_key, pkcs12
 
-from tests.unit.charms.tls_certificates_interface.v1.certificates import (
+from tests.unit.charms.tls_certificates_interface.v2.certificates import (
     generate_ca as generate_ca_helper,
 )
-from tests.unit.charms.tls_certificates_interface.v1.certificates import (
+from tests.unit.charms.tls_certificates_interface.v2.certificates import (
     generate_certificate as generate_certificate_helper,
 )
-from tests.unit.charms.tls_certificates_interface.v1.certificates import (
+from tests.unit.charms.tls_certificates_interface.v2.certificates import (
     generate_csr as generate_csr_helper,
 )
-from tests.unit.charms.tls_certificates_interface.v1.certificates import (
+from tests.unit.charms.tls_certificates_interface.v2.certificates import (
     generate_private_key as generate_private_key_helper,
 )
 

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
@@ -8,14 +8,14 @@ from unittest.mock import PropertyMock, call, patch
 
 from ops import testing
 
-from tests.unit.charms.tls_certificates_interface.v1.dummy_provider_charm.src.charm import (
+from tests.unit.charms.tls_certificates_interface.v2.dummy_provider_charm.src.charm import (
     DummyTLSCertificatesProviderCharm,
 )
 
 testing.SIMULATE_CAN_CONNECT = True
 
-BASE_CHARM_DIR = "tests.unit.charms.tls_certificates_interface.v1.dummy_provider_charm.src.charm.DummyTLSCertificatesProviderCharm"  # noqa: E501
-LIB_DIR = "lib.charms.tls_certificates_interface.v1.tls_certificates"
+BASE_CHARM_DIR = "tests.unit.charms.tls_certificates_interface.v2.dummy_provider_charm.src.charm.DummyTLSCertificatesProviderCharm"  # noqa: E501
+LIB_DIR = "lib.charms.tls_certificates_interface.v2.tls_certificates"
 
 
 def _load_relation_data(raw_relation_data: dict) -> dict:
@@ -150,7 +150,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
 
         patch_certificate_creation_request.assert_not_called()
 
-    @patch(f"{LIB_DIR}.TLSCertificatesProvidesV1.remove_certificate")
+    @patch(f"{LIB_DIR}.TLSCertificatesProvidesV2.remove_certificate")
     @patch(
         f"{LIB_DIR}.CertificatesProviderCharmEvents.certificate_revocation_request",
     )
@@ -194,7 +194,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             chain=chain,
         )
 
-    @patch(f"{LIB_DIR}.TLSCertificatesProvidesV1.remove_certificate")
+    @patch(f"{LIB_DIR}.TLSCertificatesProvidesV2.remove_certificate")
     @patch(
         f"{LIB_DIR}.CertificatesProviderCharmEvents.certificate_revocation_request",
         new_callable=PropertyMock,
@@ -435,6 +435,31 @@ class TestTLSCertificatesProvides(unittest.TestCase):
                 )
             },
         )
+
+    def test_given_unit_is_not_leader_when_set_relation_certificate_then(self):
+        self.harness.set_leader(is_leader=False)
+        remote_app_1 = "tls-requirer-1"
+        remote_app_1_unit_name = "tls-requirer-1/0"
+        relation_id = self.harness.add_relation(
+            relation_name=self.relation_name, remote_app=remote_app_1
+        )
+        self.harness.add_relation_unit(
+            relation_id=relation_id, remote_unit_name=remote_app_1_unit_name
+        )
+
+        self.harness.charm.certificates.set_relation_certificate(
+            certificate="whatever certificate",
+            ca="whatever ca",
+            chain=["whatever cert 1", "whatever cert 2"],
+            certificate_signing_request="whatever certificate signing request",
+            relation_id=relation_id,
+        )
+
+        relation_data = self.harness.get_relation_data(
+            relation_id=relation_id, app_or_unit=self.harness.charm.app
+        )
+
+        self.assertEqual(relation_data, {})
 
     def test_given_certificate_in_relation_data_when_remove_certificate_then_certificate_is_removed_from_relation(  # noqa: E501
         self,


### PR DESCRIPTION
# Description

Only sets relation certificate when unit is leader.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
