### PR TITLE
use pydeps

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -14,10 +14,6 @@ From a charm directory, fetch the library using `charmcraft`:
 charmcraft fetch-lib charms.tls_certificates_interface.v2.tls_certificates
 ```
 
-Add the following libraries to the charm's `requirements.txt` file:
-- jsonschema
-- cryptography
-
 Add the following section to the charm's `charmcraft.yaml` file:
 ```yaml
 parts:
@@ -308,7 +304,9 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
+
+PYDEPS = ["cryptography", "jsonschema"]
 
 REQUIRER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -14,6 +14,10 @@ From a charm directory, fetch the library using `charmcraft`:
 charmcraft fetch-lib charms.tls_certificates_interface.v2.tls_certificates
 ```
 
+Add the following libraries to the charm's `requirements.txt` file:
+- jsonschema
+- cryptography
+
 Add the following section to the charm's `charmcraft.yaml` file:
 ```yaml
 parts:


### PR DESCRIPTION
# Description

Charmcraft now supports the PYDEPS feature which pulls in libraries with pip automatically so users do not need to add them to requirements.txt.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
        (Is this really needed for this change?
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
