### PR TITLE
Adds methods to fetch certificates issued

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -276,6 +276,7 @@ import copy
 import json
 import logging
 import uuid
+from collections import defaultdict
 from contextlib import suppress
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address
@@ -1063,13 +1064,11 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             dict: Certificates per application name.
         """
-        certificates: Dict[str, List[str]] = {}
+        certificates: Dict[str, List[str]] = defaultdict(list)
         for relation in self.model.relations[self.relationship_name]:
             provider_relation_data = _load_relation_data(relation.data[self.charm.app])
             provider_certificates = provider_relation_data.get("certificates", [])
             for certificate in provider_certificates:
-                if relation.app.name not in certificates:  # type: ignore[union-attr]
-                    certificates[relation.app.name] = []  # type: ignore[union-attr]
                 certificates[relation.app.name].append(certificate["certificate"])  # type: ignore[union-attr]
         return certificates
 

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1506,7 +1506,6 @@ class TLSCertificatesRequiresV2(Object):
 
     def _find_certificate_in_relation_data(self, csr: str) -> Optional[Dict[str, Any]]:
         """Returns the certificate that match the given CSR."""
-
         for certificate_dict in self._provider_certificates:
             if certificate_dict["certificate_signing_request"] != csr:
                 continue

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1218,7 +1218,7 @@ class TLSCertificatesRequiresV2(Object):
 
     @property
     def _provider_certificates(self) -> List[Dict[str, str]]:
-        """Returns list of provider CSRs from relation data."""
+        """Returns list of certificates from the provider's relation data."""
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
             logger.debug("No relation: %s", self.relationship_name)
@@ -1505,6 +1505,8 @@ class TLSCertificatesRequiresV2(Object):
             event.secret.remove_all_revisions()
 
     def _find_certificate_in_relation_data(self, csr: str) -> Optional[Dict[str, Any]]:
+        """Returns the certificate that match the given CSR."""
+
         for certificate_dict in self._provider_certificates:
             if certificate_dict["certificate_signing_request"] != csr:
                 continue

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
@@ -731,7 +731,11 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name, key_values=key_values
         )
-        expected_certificate = {self.remote_app: [certificate]}
+        expected_certificate = {
+            self.remote_app: {
+                "whatever csr": "whatever cert",
+            }
+        }
 
         certificates = self.harness.charm.certificates.get_all_relations_certificates()
 
@@ -771,7 +775,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             "certificates": json.dumps(
                 [
                     {
-                        "certificate_signing_request": "new csr",
+                        "certificate_signing_request": "different csr",
                         "certificate": certificate_2,
                         "ca": "whatever ca",
                         "chain": ["whatever cert 1", "whatever cert 2"],
@@ -789,7 +793,14 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             app_or_unit=self.harness.charm.app.name,
             key_values=key_values_requirer_2,
         )
-        expected_certificates = {self.remote_app: [certificate_1], requirer_2_app: [certificate_2]}
+        expected_certificates = {
+            self.remote_app: {
+                "whatever csr": "whatever cert 1",
+            },
+            requirer_2_app: {
+                "different csr": "whatever cert 2",
+            },
+        }
         certificates = self.harness.charm.certificates.get_all_relations_certificates()
         self.assertEqual(certificates, expected_certificates)
 
@@ -799,7 +810,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
         self.harness.set_leader(is_leader=True)
         certificates = self.harness.charm.certificates.get_relation_certificates(relation_id)
-        self.assertEqual(certificates, [])
+        self.assertEqual(certificates, {})
 
     def test_given_certificate_in_relation_data_when_get_certificates_by_relation_id_then_certificate_is_returned(
         self,
@@ -822,7 +833,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name, key_values=key_values
         )
-        expected_certificate = [certificate]
+        expected_certificate = {"whatever csr": "whatever cert"}
 
         certificates = self.harness.charm.certificates.get_relation_certificates(
             relation_id=relation_id

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
@@ -701,3 +701,132 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         )
         provider_relation_data = _load_relation_data(provider_relation_data)
         self.assertEqual({"certificates": []}, provider_relation_data)
+
+    def test_given_no_certificates_in_relation_data_when_get_relations_certificates_then_returned_dict_is_empty(
+        self,
+    ):
+        self.create_certificates_relation_with_1_remote_unit()
+        self.harness.set_leader(is_leader=True)
+        certificates = self.harness.charm.certificates.get_all_relations_certificates()
+        self.assertEqual(certificates, {})
+
+    def test_given_one_certificate_in_relation_data_when_get_relations_certificates_then_certificate_is_returned(
+        self,
+    ):
+        relation_id = self.create_certificates_relation_with_1_remote_unit()
+        self.harness.set_leader(is_leader=True)
+        certificate = "whatever cert"
+        key_values = {
+            "certificates": json.dumps(
+                [
+                    {
+                        "certificate_signing_request": "whatever csr",
+                        "certificate": certificate,
+                        "ca": "whatever ca",
+                        "chain": ["whatever cert 1", "whatever cert 2"],
+                    }
+                ]
+            )
+        }
+        self.harness.update_relation_data(
+            relation_id=relation_id, app_or_unit=self.harness.charm.app.name, key_values=key_values
+        )
+        expected_certificate = {self.remote_app: [certificate]}
+
+        certificates = self.harness.charm.certificates.get_all_relations_certificates()
+
+        self.assertEqual(certificates, expected_certificate)
+
+    def test_given_multiple_certificate_in_relation_data_when_get_relations_certificates_then_certificate_are_returned(
+        self,
+    ):
+        relation_id_requirer_1 = self.create_certificates_relation_with_1_remote_unit()
+        requirer_2_app = "tls-certificates-requirer_2"
+        requirer_2_unit = "tls-certificates-requirer_2/0"
+        relation_id_requirer_2 = self.harness.add_relation(
+            relation_name=self.relation_name, remote_app=requirer_2_app
+        )
+        self.harness.add_relation_unit(
+            relation_id=relation_id_requirer_2, remote_unit_name=requirer_2_unit
+        )
+
+        self.harness.set_leader(is_leader=True)
+
+        certificate_1 = "whatever cert 1"
+        certificate_2 = "whatever cert 2"
+
+        key_values_requirer_1 = {
+            "certificates": json.dumps(
+                [
+                    {
+                        "certificate_signing_request": "whatever csr",
+                        "certificate": certificate_1,
+                        "ca": "whatever ca",
+                        "chain": ["whatever cert 1", "whatever cert 2"],
+                    }
+                ]
+            )
+        }
+        key_values_requirer_2 = {
+            "certificates": json.dumps(
+                [
+                    {
+                        "certificate_signing_request": "new csr",
+                        "certificate": certificate_2,
+                        "ca": "whatever ca",
+                        "chain": ["whatever cert 1", "whatever cert 2"],
+                    }
+                ]
+            )
+        }
+        self.harness.update_relation_data(
+            relation_id=relation_id_requirer_1,
+            app_or_unit=self.harness.charm.app.name,
+            key_values=key_values_requirer_1,
+        )
+        self.harness.update_relation_data(
+            relation_id=relation_id_requirer_2,
+            app_or_unit=self.harness.charm.app.name,
+            key_values=key_values_requirer_2,
+        )
+        expected_certificates = {self.remote_app: [certificate_1], requirer_2_app: [certificate_2]}
+        certificates = self.harness.charm.certificates.get_all_relations_certificates()
+        print(certificates)
+        self.assertEqual(certificates, expected_certificates)
+
+    def test_given_no_certificates_in_relation_data_when_get_certificates_by_relation_id_then_returned_dict_is_empty(
+        self,
+    ):
+        relation_id = self.create_certificates_relation_with_1_remote_unit()
+        self.harness.set_leader(is_leader=True)
+        certificates = self.harness.charm.certificates.get_relation_certificates(relation_id)
+        self.assertEqual(certificates, [])
+
+    def test_given_certificate_in_relation_data_when_get_certificates_by_relation_id_then_certificate_is_returned(
+        self,
+    ):
+        relation_id = self.create_certificates_relation_with_1_remote_unit()
+        self.harness.set_leader(is_leader=True)
+        certificate = "whatever cert"
+        key_values = {
+            "certificates": json.dumps(
+                [
+                    {
+                        "certificate_signing_request": "whatever csr",
+                        "certificate": certificate,
+                        "ca": "whatever ca",
+                        "chain": ["whatever cert 1", "whatever cert 2"],
+                    }
+                ]
+            )
+        }
+        self.harness.update_relation_data(
+            relation_id=relation_id, app_or_unit=self.harness.charm.app.name, key_values=key_values
+        )
+        expected_certificate = [certificate]
+
+        certificates = self.harness.charm.certificates.get_relation_certificates(
+            relation_id=relation_id
+        )
+
+        self.assertEqual(certificates, expected_certificate)

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
@@ -791,7 +791,6 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         )
         expected_certificates = {self.remote_app: [certificate_1], requirer_2_app: [certificate_2]}
         certificates = self.harness.charm.certificates.get_all_relations_certificates()
-        print(certificates)
         self.assertEqual(certificates, expected_certificates)
 
     def test_given_no_certificates_in_relation_data_when_get_certificates_by_relation_id_then_returned_dict_is_empty(

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
@@ -702,15 +702,15 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         provider_relation_data = _load_relation_data(provider_relation_data)
         self.assertEqual({"certificates": []}, provider_relation_data)
 
-    def test_given_no_certificates_in_relation_data_when_get_relations_certificates_then_returned_dict_is_empty(
+    def test_given_no_certificates_in_relation_data_when_get_issued_certificates_then_returned_dict_is_empty(
         self,
     ):
         self.create_certificates_relation_with_1_remote_unit()
         self.harness.set_leader(is_leader=True)
-        certificates = self.harness.charm.certificates.get_all_relations_certificates()
+        certificates = self.harness.charm.certificates.get_issued_certificates()
         self.assertEqual(certificates, {})
 
-    def test_given_one_certificate_in_relation_data_when_get_relations_certificates_then_certificate_is_returned(
+    def test_given_one_certificate_in_relation_data_when_get_issued_certificates_then_certificate_is_returned(
         self,
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
@@ -737,11 +737,11 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             }
         }
 
-        certificates = self.harness.charm.certificates.get_all_relations_certificates()
+        certificates = self.harness.charm.certificates.get_issued_certificates()
 
         self.assertEqual(certificates, expected_certificate)
 
-    def test_given_multiple_certificate_in_relation_data_when_get_relations_certificates_then_certificate_are_returned(
+    def test_given_multiple_certificate_in_relation_data_when_get_issued_certificates_then_certificate_are_returned(
         self,
     ):
         relation_id_requirer_1 = self.create_certificates_relation_with_1_remote_unit()
@@ -801,18 +801,18 @@ class TestTLSCertificatesProvides(unittest.TestCase):
                 "different csr": "whatever cert 2",
             },
         }
-        certificates = self.harness.charm.certificates.get_all_relations_certificates()
+        certificates = self.harness.charm.certificates.get_issued_certificates()
         self.assertEqual(certificates, expected_certificates)
 
-    def test_given_no_certificates_in_relation_data_when_get_certificates_by_relation_id_then_returned_dict_is_empty(
+    def test_given_no_certificates_in_relation_data_when_get_issued_certificates_by_relation_id_then_returned_dict_is_empty(
         self,
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
         self.harness.set_leader(is_leader=True)
-        certificates = self.harness.charm.certificates.get_relation_certificates(relation_id)
+        certificates = self.harness.charm.certificates.get_issued_certificates(relation_id)
         self.assertEqual(certificates, {})
 
-    def test_given_certificate_in_relation_data_when_get_certificates_by_relation_id_then_certificate_is_returned(
+    def test_given_certificate_in_relation_data_when_get_issued_certificates_by_relation_id_then_certificate_is_returned(
         self,
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
@@ -833,9 +833,13 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name, key_values=key_values
         )
-        expected_certificate = {"whatever csr": "whatever cert"}
+        expected_certificate = {
+            self.remote_app: {
+                "whatever csr": "whatever cert",
+            }
+        }
 
-        certificates = self.harness.charm.certificates.get_relation_certificates(
+        certificates = self.harness.charm.certificates.get_issued_certificates(
             relation_id=relation_id
         )
 


### PR DESCRIPTION
# Description

Allows getting the issued certificates from the databags. Either by getting all certificates for all relations or getting certificates by relation ID.

The goal is to allow the provider charms to implement actions that list the issued certificates, addressing [this issue](https://github.com/canonical/self-signed-certificates-operator/issues/9).

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
