### PR TITLE
Access the relation databag if unit is leader

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -308,7 +308,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 PYDEPS = ["cryptography", "jsonschema"]
 

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1127,7 +1127,8 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             None
         """
-        assert event.unit is not None
+        if event.unit is None:
+            return
         requirer_relation_data = self._load_relation_data(event.relation.data[event.unit])
         provider_relation_data = self._load_relation_data(event.relation.data[self.charm.app])
         if not self._relation_data_is_valid(requirer_relation_data):

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
@@ -81,6 +81,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         self.harness = testing.Harness(DummyTLSCertificatesProviderCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        self.harness.set_leader(is_leader=True)
 
     def create_certificates_relation_with_1_remote_unit(self) -> int:
         relation_id = self.harness.add_relation(

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
@@ -41,6 +41,7 @@ class TestJuju2(unittest.TestCase):
         self.harness = testing.Harness(DummyTLSCertificatesRequirerCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        self.harness.set_leader(is_leader=True)
 
     def create_certificates_relation(self) -> int:
         relation_id = self.harness.add_relation(
@@ -797,6 +798,7 @@ class TestJuju3(unittest.TestCase):
         self.harness = testing.Harness(DummyTLSCertificatesRequirerCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        self.harness.set_leader(is_leader=True)
 
     def create_certificates_relation(self) -> int:
         relation_id = self.harness.add_relation(


### PR DESCRIPTION
# Description

This aims to fix https://github.com/canonical/tls-certificates-interface/issues/58 and  https://github.com/canonical/self-signed-certificates-operator/issues/24. Within this change, non-leader does not try to access app relation databag and Permission denied error does not appear.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
