### PR TITLE
Add KeyUsage extension to generated CA certificates

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -668,7 +668,7 @@ def generate_ca(
             ),
             critical=False,
         )
-        .add_extension(key_usage, critical=False)
+        .add_extension(key_usage, critical=True)
         .add_extension(
             x509.BasicConstraints(ca=True, path_length=None),
             critical=True,

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -308,7 +308,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -640,6 +640,17 @@ def generate_ca(
         private_key_object.public_key()  # type: ignore[arg-type]
     )
     subject_identifier = key_identifier = subject_identifier_object.public_bytes()
+    key_usage = x509.KeyUsage(
+        digital_signature=True,
+        key_encipherment=True,
+        key_cert_sign=True,
+        key_agreement=False,
+        content_commitment=False,
+        data_encipherment=False,
+        crl_sign=False,
+        encipher_only=False,
+        decipher_only=False,
+    )
     cert = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -657,6 +668,7 @@ def generate_ca(
             ),
             critical=False,
         )
+        .add_extension(key_usage, critical=False)
         .add_extension(
             x509.BasicConstraints(ca=True, path_length=None),
             critical=True,

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2.py
@@ -198,6 +198,20 @@ def test_given_private_key_and_subject_when_generate_ca_then_ca_is_generated_cor
         ]
     )
     assert certificate_public_key == initial_public_key
+    assert (
+        x509.KeyUsage(
+            digital_signature=True,
+            key_encipherment=True,
+            key_cert_sign=True,
+            key_agreement=False,
+            content_commitment=False,
+            data_encipherment=False,
+            crl_sign=False,
+            encipher_only=False,
+            decipher_only=False,
+        )
+        == cert.extensions.get_extension_for_class(x509.KeyUsage).value
+    )
 
 
 def test_given_csr_and_ca_when_generate_certificate_then_certificate_is_generated_with_correct_subject_and_issuer():  # noqa: E501

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2.py
@@ -212,6 +212,7 @@ def test_given_private_key_and_subject_when_generate_ca_then_ca_is_generated_cor
         )
         == cert.extensions.get_extension_for_class(x509.KeyUsage).value
     )
+    assert cert.extensions.get_extension_for_class(x509.KeyUsage).critical
 
 
 def test_given_csr_and_ca_when_generate_certificate_then_certificate_is_generated_with_correct_subject_and_issuer():  # noqa: E501


### PR DESCRIPTION
# Description

Add KeyUsage extension to generated CA certificates. This is required to follow `RFC 5280 Section 4.2.1.3` and fixes #71 

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
