### PR TITLE
Add more extensions

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -760,7 +760,7 @@ def generate_certificate(
             critical=extension.critical,
         )
 
-    # Filter out default extension that were overridden by the caller. Without this step we'd get
+    # Filter out default extensions that were overridden by the caller. Without this step we'd get
     # ValueError: This extension has already been set.
     additional_extensions = additional_extensions or []
     additional_extensions_oids = [extension.oid for extension in additional_extensions]

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -308,7 +308,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 PYDEPS = ["cryptography", "jsonschema"]
 

--- a/tests/unit/charms/tls_certificates_interface/v2/test_certificates.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_certificates.py
@@ -1,0 +1,77 @@
+import unittest
+
+from charms.tls_certificates_interface.v2.tls_certificates import (
+    generate_ca,
+    generate_certificate,
+    generate_csr,
+    generate_private_key,
+)
+from cryptography import x509
+
+
+class TestCertificates(unittest.TestCase):
+    def setUp(self, *unused):
+        self.ca_private_key = generate_private_key()
+        self.ca = generate_ca(
+            private_key=self.ca_private_key,
+            subject="my.demo.ca",
+        )
+        self.ca_pem = x509.load_pem_x509_certificate(self.ca)
+
+        self.server_private_key = generate_private_key()
+        self.server_csr = generate_csr(
+            private_key=self.server_private_key,
+            subject="10.10.10.10",
+            sans_dns=[],
+            sans_ip=["10.10.10.10"],
+        )
+
+    def test_cert_akid_matched_ca_skid(self):
+        # WHEN creating a certificate signed by the CA
+        server_cert = x509.load_pem_x509_certificate(
+            generate_certificate(csr=self.server_csr, ca=self.ca, ca_key=self.ca_private_key)
+        )
+
+        # THEN the new certificate's AKID is identical to the CA cert's SKID
+        self.assertEqual(
+            server_cert.extensions.get_extension_for_class(
+                x509.AuthorityKeyIdentifier
+            ).value.key_identifier,
+            self.ca_pem.extensions.get_extension_for_class(
+                x509.SubjectKeyIdentifier
+            ).value.key_identifier,
+        )
+
+    def test_additional_cert_extensions_override_default_extensions(self):
+        # WHEN creating a certificate without passing additional extensions
+        server_cert = x509.load_pem_x509_certificate(
+            generate_certificate(csr=self.server_csr, ca=self.ca, ca_key=self.ca_private_key)
+        )
+
+        # THEN the new certificate has a "CA: FALSE" basic extension
+        self.assertEqual(
+            server_cert.extensions.get_extension_for_class(x509.BasicConstraints).value,
+            x509.BasicConstraints(ca=False, path_length=None),
+        )
+
+        # BUT WHEN a default extension is overridden
+        server_cert = x509.load_pem_x509_certificate(
+            generate_certificate(
+                csr=self.server_csr,
+                ca=self.ca,
+                ca_key=self.ca_private_key,
+                additional_extensions=[
+                    x509.Extension(
+                        x509.ExtensionOID.BASIC_CONSTRAINTS,
+                        critical=False,
+                        value=x509.BasicConstraints(ca=True, path_length=2),
+                    )
+                ],
+            )
+        )
+
+        # THEN the new certificate has the overridden value
+        self.assertEqual(
+            server_cert.extensions.get_extension_for_class(x509.BasicConstraints).value,
+            x509.BasicConstraints(ca=True, path_length=2),
+        )

--- a/tests/unit/charms/tls_certificates_interface/v2/test_certificates.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_certificates.py
@@ -41,37 +41,3 @@ class TestCertificates(unittest.TestCase):
                 x509.SubjectKeyIdentifier
             ).value.key_identifier,
         )
-
-    def test_additional_cert_extensions_override_default_extensions(self):
-        # WHEN creating a certificate without passing additional extensions
-        server_cert = x509.load_pem_x509_certificate(
-            generate_certificate(csr=self.server_csr, ca=self.ca, ca_key=self.ca_private_key)
-        )
-
-        # THEN the new certificate has a "CA: FALSE" basic extension
-        self.assertEqual(
-            server_cert.extensions.get_extension_for_class(x509.BasicConstraints).value,
-            x509.BasicConstraints(ca=False, path_length=None),
-        )
-
-        # BUT WHEN a default extension is overridden
-        server_cert = x509.load_pem_x509_certificate(
-            generate_certificate(
-                csr=self.server_csr,
-                ca=self.ca,
-                ca_key=self.ca_private_key,
-                additional_extensions=[
-                    x509.Extension(
-                        x509.ExtensionOID.BASIC_CONSTRAINTS,
-                        critical=False,
-                        value=x509.BasicConstraints(ca=True, path_length=2),
-                    )
-                ],
-            )
-        )
-
-        # THEN the new certificate has the overridden value
-        self.assertEqual(
-            server_cert.extensions.get_extension_for_class(x509.BasicConstraints).value,
-            x509.BasicConstraints(ca=True, path_length=2),
-        )


### PR DESCRIPTION
# Description

Before this PR, `openssl verify` was failing for certs generated by the self-signed-certfiicates operator. For example:
- `verify error:num=21:unable to verify the first certificate`
- `error 85 at 0 depth lookup: Missing Authority Key Identifier`
- `verify error:num=30:authority and subject key identifier mismatch`

With the changes in this PR, verification passes (`10.43.8.206` is traefik's IP):
```
# echo | openssl s_client -showcerts -servername 10.43.8.206 -connect 10.43.8.206:443 | openssl x509 > test.crt
depth=1 C = US, CN = external.demo.ca
verify return:1
depth=0 CN = 10.43.8.206, x500UniqueIdentifier = 6e1b0143-392e-428b-87d7-5b240f9d90ee
verify return:1
DONE

# openssl verify -x509_strict -verbose -verify_ip 10.43.8.206 test.crt
test.crt: OK
```

Fixes #73.

## Details
### Authority Key Identifier (AKID) and Subject Key Identifier (SKID)
- For the root CA, AKID=SKID (this is already implemented before this PR)
- For intermediate CAs and certs, the AKID must match the CA's SKID
![AKID chain](https://github.com/canonical/tls-certificates-interface/assets/82407168/2d80fba8-75d5-4c36-ad39-935dfff214ee)

### Basic Constraints
For server certs, "CA" needs to be set to "FALSE".

### Extended Key Usage
Sample value:
```
            X509v3 Extended Key Usage: 
                TLS Web Server Authentication, TLS Web Client Authentication
```
This extension was not added as part of this PR.

### Certificate Policies
Sample value:
```
            X509v3 Certificate Policies: 
                Policy: 2.23.140.1.2.2
                  CPS: http://www.digicert.com/CPS
```
This extension was not added as part of this PR.

## References
- [1.1.1.1](https://1.1.1.1/) and `echo | openssl s_client -showcerts -servername 1.1.1.1 -connect 1.1.1.1:443 | openssl x509 -noout -text`
- https://security.stackexchange.com/a/200301/58740

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
