### PR TITLE
bugfix: Validates modulus in csr/cert comparison instead of subject

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -308,7 +308,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 17
+LIBPATCH = 18
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1701,7 +1701,10 @@ def csr_matches_certificate(csr: str, cert: str) -> bool:
             format=serialization.PublicFormat.SubjectPublicKeyInfo,
         ):
             return False
-        if csr_object.subject != cert_object.subject:
+        if (
+            csr_object.public_key().public_numbers().n  # type: ignore[union-attr]
+            != cert_object.public_key().public_numbers().n  # type: ignore[union-attr]
+        ):
             return False
     except ValueError:
         logger.warning("Could not load certificate or CSR.")

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
@@ -63,7 +63,7 @@ class TestJuju2(unittest.TestCase):
         csr = generate_csr_helper(
             private_key=private_key,
             private_key_password=private_key_password,
-            subject="whatver subject",
+            common_name="whatver subject",
         )
 
         self.harness.charm.certificates.request_certificate_creation(
@@ -86,7 +86,9 @@ class TestJuju2(unittest.TestCase):
         private_key_password = b"whatever"
         private_key = generate_private_key_helper(password=private_key_password)
         csr = generate_csr_helper(
-            private_key=private_key, private_key_password=private_key_password, subject=common_name
+            private_key=private_key,
+            private_key_password=private_key_password,
+            common_name=common_name,
         )
         key_values = {
             "certificate_signing_requests": json.dumps(
@@ -122,12 +124,12 @@ class TestJuju2(unittest.TestCase):
         initial_csr = generate_csr_helper(
             private_key=private_key,
             private_key_password=private_key_password,
-            subject=initial_common_name,
+            common_name=initial_common_name,
         )
         new_csr = generate_csr_helper(
             private_key=private_key,
             private_key_password=private_key_password,
-            subject=new_common_name,
+            common_name=new_common_name,
         )
         key_values = {
             "certificate_signing_requests": json.dumps(
@@ -360,11 +362,15 @@ class TestJuju2(unittest.TestCase):
         private_key = generate_private_key_helper(password=private_key_password)
         ca_key = generate_private_key_helper(password=ca_private_key_password)
         certificate_signing_request = generate_csr_helper(
-            private_key=private_key, private_key_password=private_key_password, subject="whatever"
+            private_key=private_key,
+            private_key_password=private_key_password,
+            common_name="whatever",
         )
 
         ca_certificate = generate_ca_helper(
-            private_key=ca_key, private_key_password=ca_private_key_password, subject="whatever"
+            private_key=ca_key,
+            private_key_password=ca_private_key_password,
+            common_name="whatever",
         )
 
         certificate = generate_certificate_helper(
@@ -411,11 +417,15 @@ class TestJuju2(unittest.TestCase):
         private_key = generate_private_key_helper(password=private_key_password)
         ca_key = generate_private_key_helper(password=ca_private_key_password)
         certificate_signing_request = generate_csr_helper(
-            private_key=private_key, private_key_password=private_key_password, subject="whatever"
+            private_key=private_key,
+            private_key_password=private_key_password,
+            common_name="whatever",
         )
 
         ca_certificate = generate_ca_helper(
-            private_key=ca_key, private_key_password=ca_private_key_password, subject="whatever"
+            private_key=ca_key,
+            private_key_password=ca_private_key_password,
+            common_name="whatever",
         )
 
         certificate = generate_certificate_helper(
@@ -459,11 +469,15 @@ class TestJuju2(unittest.TestCase):
         private_key = generate_private_key_helper(password=private_key_password)
         ca_key = generate_private_key_helper(password=ca_private_key_password)
         certificate_signing_request = generate_csr_helper(
-            private_key=private_key, private_key_password=private_key_password, subject="whatever"
+            private_key=private_key,
+            private_key_password=private_key_password,
+            common_name="whatever",
         )
 
         ca_certificate = generate_ca_helper(
-            private_key=ca_key, private_key_password=ca_private_key_password, subject="whatever"
+            private_key=ca_key,
+            private_key_password=ca_private_key_password,
+            common_name="whatever",
         )
 
         certificate = generate_certificate_helper(
@@ -516,11 +530,15 @@ class TestJuju2(unittest.TestCase):
         private_key = generate_private_key_helper(password=private_key_password)
         ca_key = generate_private_key_helper(password=ca_private_key_password)
         certificate_signing_request = generate_csr_helper(
-            private_key=private_key, private_key_password=private_key_password, subject="whatever"
+            private_key=private_key,
+            private_key_password=private_key_password,
+            common_name="whatever",
         )
 
         ca_certificate = generate_ca_helper(
-            private_key=ca_key, private_key_password=ca_private_key_password, subject="whatever"
+            private_key=ca_key,
+            private_key_password=ca_private_key_password,
+            common_name="whatever",
         )
 
         certificate = generate_certificate_helper(
@@ -815,11 +833,15 @@ class TestJuju3(unittest.TestCase):
         private_key = generate_private_key_helper(password=private_key_password)
         ca_key = generate_private_key_helper(password=ca_private_key_password)
         certificate_signing_request = generate_csr_helper(
-            private_key=private_key, private_key_password=private_key_password, subject="whatever"
+            private_key=private_key,
+            private_key_password=private_key_password,
+            common_name="whatever",
         )
 
         ca_certificate = generate_ca_helper(
-            private_key=ca_key, private_key_password=ca_private_key_password, subject="whatever"
+            private_key=ca_key,
+            private_key_password=ca_private_key_password,
+            common_name="whatever",
         )
 
         certificate = generate_certificate_helper(


### PR DESCRIPTION
# Description

It is possible for a certificate subject to not match its CSR and still be valid. For instance the country and orgs can be different. We now validate the modulus only when validating that a certificate matches a CSR. This change is necessary in order to fix this issue: https://github.com/canonical/manual-tls-certificates-operator/issues/77

## Reference
- https://www.ssl.com/faqs/how-do-i-confirm-that-a-private-key-matches-a-csr-and-certificate/

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
