### PR TITLE
docs: Adds Charmhub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # tls-certificates-interface
-
-## Description
+[![CharmHub Badge](https://charmhub.io/tls-certificates-interface/badge.svg)](https://charmhub.io/tls-certificates-interface/libraries/tls_certificates)
 
 This project contains libraries for the tls-certificates relationship. It contains both the 
 provider and the requirer side of the relation.


### PR DESCRIPTION
# Description

The Telco charms currently have broken statuses in the [charm engineering page](https://releases.juju.is/?team=Telco). This PR adds the appropriate charmhub badge to address this.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
