### PR TITLE
feat: get_certificates and get_csrs

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1678,6 +1678,7 @@ class TLSCertificatesRequiresV2(Object):
         """
         final_list = []
         for csr in self.get_certificate_signing_requests(fulfilled_only=True):
+            assert type(csr["certificate_signing_request"]) == str
             if cert := self._find_certificate_in_relation_data(csr["certificate_signing_request"]):
                 final_list.append(cert)
         return final_list

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1021,11 +1021,9 @@ def generate_csr(
 def csr_matches_certificate(csr: str, cert: str) -> bool:
     """Check if a CSR matches a certificate.
 
-    expects to get the original string representations.
-
     Args:
-        csr (str): Certificate Signing Request
-        cert (str): Certificate
+        csr (str): Certificate Signing Request as a string
+        cert (str): Certificate as a string
     Returns:
         bool: True/False depending on whether the CSR matches the certificate.
     """

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -308,7 +308,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 21
+LIBPATCH = 22
 
 PYDEPS = ["cryptography", "jsonschema"]
 

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1676,7 +1676,11 @@ class TLSCertificatesRequiresV2(Object):
                 }
             ]
         """
-        return self._provider_certificates
+        final_list = []
+        for csr in self.get_certificate_signing_requests(fulfilled_only=True):
+            if cert := self._find_certificate_in_relation_data(csr["certificate_signing_request"]):
+                final_list.append(cert)
+        return final_list
 
     def get_certificate_signing_requests(
         # RFC: Should I just split this up into 3 different functions?

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1515,7 +1515,7 @@ class TLSCertificatesRequiresV2(Object):
 
     @property
     def _requirer_csrs(self) -> List[Dict[str, Union[bool, str]]]:
-        """Returns list of requirer's CSRs from relation data.
+        """Returns list of requirer's CSRs from relation unit data.
 
         Example:
             [
@@ -1685,7 +1685,6 @@ class TLSCertificatesRequiresV2(Object):
 
     def get_certificate_signing_requests(
         # RFC: Should I just split this up into 3 different functions?
-        # RFC: Should we have an option where the leader will aggregate all of the CSR's from all of the units of the application?
         self,
         fulfilled_only: bool = False,
         unfulfilled_only: bool = False,
@@ -1694,6 +1693,10 @@ class TLSCertificatesRequiresV2(Object):
 
         You can choose to get only the CSR's that have a certificate assigned or only the CSR's
         that don't.
+
+        Args:
+            fulfilled_only (bool): This option will discard CSRs that don't have certificates yet.
+            unfulfilled_only (bool): This option will discard CSRs that have certificates signed.
 
         Returns:
             List of CSR dictionaries. For example:

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
@@ -1146,7 +1146,7 @@ class TestJuju3(unittest.TestCase):
         assert secret.get_content(refresh=True)["certificate"] == certificate
         assert secret.get_info().expires == expiry_time - timedelta(hours=168)
 
-    def test_given_certificates_available_when_get_assigned_certificates_then_all_certificates_returned(
+    def test_given_certificates_available_when_get_assigned_certificates_then_unit_certificates_returned_only(
         self,
     ):  # noqa: E501
         relation_id = self.create_certificates_relation()
@@ -1163,7 +1163,13 @@ class TestJuju3(unittest.TestCase):
                         "chain": ["cert1"],
                         "certificate_signing_request": "csr1",
                         "certificate": "cert1",
-                    }
+                    },
+                    {
+                        "ca": "cacert2",
+                        "chain": ["cert2"],
+                        "certificate_signing_request": "csr2",
+                        "certificate": "cert2",
+                    },
                 ]
             )
         }

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
@@ -1188,6 +1188,46 @@ class TestJuju3(unittest.TestCase):
 
         assert len(self.harness.charm.certificates.get_assigned_certificates()) == 1
 
+    def test_given_certificates_available_when_get_assigned_certificates_with_no_csrs_then_no_certificates_returned(
+        self,
+    ):  # noqa: E501
+        relation_id = self.create_certificates_relation()
+
+        unit_relation_data = {"certificate_signing_requests": json.dumps([])}
+
+        remote_app_relation_data = {
+            "certificates": json.dumps(
+                [
+                    {
+                        "ca": "cacert1",
+                        "chain": ["cert1"],
+                        "certificate_signing_request": "csr1",
+                        "certificate": "cert1",
+                    },
+                    {
+                        "ca": "cacert2",
+                        "chain": ["cert2"],
+                        "certificate_signing_request": "csr2",
+                        "certificate": "cert2",
+                    },
+                ]
+            )
+        }
+
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            app_or_unit=self.harness.charm.unit.name,
+            key_values=unit_relation_data,
+        )
+
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            app_or_unit=self.remote_app,
+            key_values=remote_app_relation_data,
+        )
+
+        assert len(self.harness.charm.certificates.get_assigned_certificates()) == 0
+
     def test_given_csrs_created_when_get_certificate_signing_requests_then_all_csrs_returned(self):
         relation_id = self.create_certificates_relation()
 

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
@@ -1187,7 +1187,9 @@ class TestJuju3(unittest.TestCase):
         )
 
         assert len(self.harness.charm.certificates.get_assigned_certificates()) == 1
-        self.assertEqual(self.harness.charm.certificates.get_assigned_certificates()[0]["certificate"], "cert1")
+        self.assertEqual(
+            self.harness.charm.certificates.get_assigned_certificates()[0]["certificate"], "cert1"
+        )
 
     def test_given_certificates_available_when_get_assigned_certificates_with_no_csrs_then_no_certificates_returned(
         self,

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
@@ -1187,6 +1187,7 @@ class TestJuju3(unittest.TestCase):
         )
 
         assert len(self.harness.charm.certificates.get_assigned_certificates()) == 1
+        self.assertEqual(self.harness.charm.certificates.get_assigned_certificates()[0]["certificate"], "cert1")
 
     def test_given_certificates_available_when_get_assigned_certificates_with_no_csrs_then_no_certificates_returned(
         self,

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
@@ -1229,17 +1229,139 @@ class TestJuju3(unittest.TestCase):
         )
         assert len(self.harness.charm.certificates.get_certificate_signing_requests()) == 2
 
+    def test_given_csrs_created_when_get_fulfilled_csrs_only_then_correct_csrs_returned(self):
+        relation_id = self.create_certificates_relation()
+
+        unit_relation_data = {
+            "certificate_signing_requests": json.dumps(
+                [{"certificate_signing_request": "csr1"}, {"certificate_signing_request": "csr3"}]
+            )
+        }
+
+        remote_app_relation_data = {
+            "certificates": json.dumps(
+                [
+                    {
+                        "ca": "cacert1",
+                        "chain": ["cert1"],
+                        "certificate_signing_request": "csr1",
+                        "certificate": "cert1",
+                    },
+                    {
+                        "ca": "cacert1",
+                        "chain": ["cert2"],
+                        "certificate_signing_request": "csr2",
+                        "certificate": "cert2",
+                    },
+                ]
+            )
+        }
+
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            app_or_unit=self.harness.charm.unit.name,
+            key_values=unit_relation_data,
+        )
+
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            app_or_unit=self.remote_app,
+            key_values=remote_app_relation_data,
+        )
+
         output = self.harness.charm.certificates.get_certificate_signing_requests(
             fulfilled_only=True
         )
         assert len(output) == 1
         assert output[0]["certificate_signing_request"] == "csr1"
 
+    def test_given_csrs_created_when_get_unfulfilled_csrs_only_then_correct_csrs_returned(self):
+        relation_id = self.create_certificates_relation()
+
+        unit_relation_data = {
+            "certificate_signing_requests": json.dumps(
+                [{"certificate_signing_request": "csr1"}, {"certificate_signing_request": "csr3"}]
+            )
+        }
+
+        remote_app_relation_data = {
+            "certificates": json.dumps(
+                [
+                    {
+                        "ca": "cacert1",
+                        "chain": ["cert1"],
+                        "certificate_signing_request": "csr1",
+                        "certificate": "cert1",
+                    },
+                    {
+                        "ca": "cacert1",
+                        "chain": ["cert2"],
+                        "certificate_signing_request": "csr2",
+                        "certificate": "cert2",
+                    },
+                ]
+            )
+        }
+
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            app_or_unit=self.harness.charm.unit.name,
+            key_values=unit_relation_data,
+        )
+
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            app_or_unit=self.remote_app,
+            key_values=remote_app_relation_data,
+        )
+
         output = self.harness.charm.certificates.get_certificate_signing_requests(
             unfulfilled_only=True
         )
         assert len(output) == 1
         assert output[0]["certificate_signing_request"] == "csr3"
+
+    def test_given_csrs_created_when_get_unfulfilled_and_fulfilled_csrs_only_then_no_csrs_returned(
+        self,
+    ):
+        relation_id = self.create_certificates_relation()
+
+        unit_relation_data = {
+            "certificate_signing_requests": json.dumps(
+                [{"certificate_signing_request": "csr1"}, {"certificate_signing_request": "csr3"}]
+            )
+        }
+
+        remote_app_relation_data = {
+            "certificates": json.dumps(
+                [
+                    {
+                        "ca": "cacert1",
+                        "chain": ["cert1"],
+                        "certificate_signing_request": "csr1",
+                        "certificate": "cert1",
+                    },
+                    {
+                        "ca": "cacert1",
+                        "chain": ["cert2"],
+                        "certificate_signing_request": "csr2",
+                        "certificate": "cert2",
+                    },
+                ]
+            )
+        }
+
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            app_or_unit=self.harness.charm.unit.name,
+            key_values=unit_relation_data,
+        )
+
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            app_or_unit=self.remote_app,
+            key_values=remote_app_relation_data,
+        )
 
         output = self.harness.charm.certificates.get_certificate_signing_requests(
             fulfilled_only=True, unfulfilled_only=True


### PR DESCRIPTION
# Description

Added 2 new functions:
`get_assigned_certificates` gets all of the certificates that are available in the remote application databag.
`get_certificate_signing_requests` gets all of the generated certificate signing requests. It also provides the option to filter the csrs by wether they have their certificate available or not. 

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
