### PR TITLE
chore: Add redefinition static check

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -307,7 +307,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 24
+LIBPATCH = 25
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -678,7 +678,7 @@ def generate_ca(
     private_key_object = serialization.load_pem_private_key(
         private_key, password=private_key_password
     )
-    subject = issuer = x509.Name(
+    subject_name = x509.Name(
         [
             x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
             x509.NameAttribute(x509.NameOID.COMMON_NAME, subject),
@@ -701,8 +701,8 @@ def generate_ca(
     )
     cert = (
         x509.CertificateBuilder()
-        .subject_name(subject)
-        .issuer_name(issuer)
+        .subject_name(subject_name)
+        .issuer_name(subject_name)
         .public_key(private_key_object.public_key())  # type: ignore[arg-type]
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.utcnow())

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -312,7 +312,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -707,7 +707,7 @@ def generate_ca(
     private_key_object = serialization.load_pem_private_key(
         private_key, password=private_key_password
     )
-    subject = issuer = x509.Name(
+    subject_name = x509.Name(
         [
             x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
             x509.NameAttribute(x509.NameOID.COMMON_NAME, subject),
@@ -730,8 +730,8 @@ def generate_ca(
     )
     cert = (
         x509.CertificateBuilder()
-        .subject_name(subject)
-        .issuer_name(issuer)
+        .subject_name(subject_name)
+        .issuer_name(subject_name)
         .public_key(private_key_object.public_key())  # type: ignore[arg-type]
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.utcnow())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ show_error_codes = true
 namespace_packages = true
 explicit_package_bases = true
 check_untyped_defs = true
-allow_redefinition = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]


### PR DESCRIPTION
# Description

 `subject` was a parameter **and** a variable in the `generate_ca` function. Here we remove this redefinition and add the static check that will prevent this category of static errors from re-occuring in the future. 

## Logs

```
lib/charms/tls_certificates_interface/v3/tls_certificates.py:710: error: Incompatible types in assignment (expression has type "Name", variable has type "str")  [assignment]
        subject = issuer = x509.Name(
        ^
lib/charms/tls_certificates_interface/v3/tls_certificates.py:733: error: Argument 1 to "subject_name" of "CertificateBuilder" has incompatible type "str"; expected "Name"  [arg-type]
            .subject_name(subject)
                          ^~~~~~~
lib/charms/tls_certificates_interface/v2/tls_certificates.py:681: error: Incompatible types in assignment (expression has type "Name", variable has type "str")  [assignment]
        subject = issuer = x509.Name(
        ^
lib/charms/tls_certificates_interface/v2/tls_certificates.py:704: error: Argument 1 to "subject_name" of "CertificateBuilder" has incompatible type "str"; expected "Name"  [arg-type]
            .subject_name(subject)
                          ^~~~~~~
Found 4 errors in 2 files (checked 4 source files)
static: exit 1 (2.68 seconds) /home/guillaume/code/tls-certificates-interface> mypy /home/guillaume/code/tls-certificates-interface/lib/ pid=953005
  static: FAIL code 1 (17.46=setup[14.78]+cmd[2.68] seconds)
  evaluation failed :( (17.51 seconds)
```

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
