### PR TITLE
fix: use build-packages in dummy charm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,17 @@ jobs:
   build:
     name: Build charm
     runs-on: ubuntu-22.04
+    needs:
+      - unit-tests-with-coverage
+      - lint-report
+      - static-analysis
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+          channel: 5.0/stable
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
       - name: Build charm
@@ -47,6 +56,8 @@ jobs:
   integration-tests-v2-juju-2:
     name: Integration tests for tls interface v2 (Juju 2.9)
     runs-on: ubuntu-22.04
+    needs:
+      - build
     steps:
       - uses: actions/checkout@v4
       - name: Setup operator environment
@@ -73,6 +84,8 @@ jobs:
   integration-tests-v2-juju-3:
     name: Integration tests for tls interface v2 (Juju 3.1)
     runs-on: ubuntu-22.04
+    needs:
+      - build
     steps:
       - uses: actions/checkout@v4
       - name: Setup operator environment
@@ -99,6 +112,8 @@ jobs:
   integration-tests-v3:
     name: Integration tests for tls interface v3
     runs-on: ubuntu-22.04
+    needs:
+      - build
     steps:
       - uses: actions/checkout@v4
       - name: Setup operator environment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,16 @@ jobs:
         run: pip install tox
       - name: Run tests using tox
         run: tox -e unit
+  
+  build:
+    name: Build charm
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Install charmcraft
+        run: snap install charmcraft --classic
+      - name: Build charm
+        run: charmcraft pack --verbose
 
   integration-tests-v2-juju-2:
     name: Integration tests for tls interface v2 (Juju 2.9)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Install charmcraft
-        run: snap install charmcraft --classic
+        run: sudo snap install charmcraft --classic
       - name: Build charm
         run: charmcraft pack --verbose
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,6 +9,9 @@ bases:
 
 parts:
   charm:
-    charm-binary-python-packages:
-      - cryptography
-      - jsonschema
+    build-packages:
+      - cargo
+      - libffi-dev
+      - libssl-dev
+      - pkg-config
+      - rustc


### PR DESCRIPTION
# Description

The build process is currently failing on `main` at the `publish charm` stage because the charm doesn't build properly there. This PR uses `build-packages` to address this issue adds a CI step to build the charm making it less likely that we merge an un-buildable charm.

## Reference:
- CI failure: https://github.com/canonical/tls-certificates-interface/actions/runs/7995294620/job/21835286164

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
