### PR TITLE
fix: return empty list when get to TLS Requirer object given no tls relation

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -1488,10 +1488,10 @@ class TLSCertificatesRequiresV3(Object):
         Returns:
             list: List of RequirerCSR objects.
         """
-        requirer_csrs = []
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
-            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+            return []
+        requirer_csrs = []
         requirer_relation_data = _load_relation_data(relation.data[self.model.unit])
         requirer_csrs_dict = requirer_relation_data.get("certificate_signing_requests", [])
         for requirer_csr_dict in requirer_csrs_dict:
@@ -1676,9 +1676,6 @@ class TLSCertificatesRequiresV3(Object):
         Returns:
             List: List[ProviderCertificate]
         """
-        if not self.model.get_relation(self.relationship_name):
-            logger.info("No relation found")
-            return []
         assigned_certificates = []
         for requirer_csr in self.get_certificate_signing_requests(fulfilled_only=True):
             if cert := self._find_certificate_in_relation_data(requirer_csr.csr):

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -312,7 +312,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1676,6 +1676,9 @@ class TLSCertificatesRequiresV3(Object):
         Returns:
             List: List[ProviderCertificate]
         """
+        if not self.model.get_relation(self.relationship_name):
+            logger.info("No relation found")
+            return []
         assigned_certificates = []
         for requirer_csr in self.get_certificate_signing_requests(fulfilled_only=True):
             if cert := self._find_certificate_in_relation_data(requirer_csr.csr):

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
@@ -972,10 +972,20 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
 
         assert len(self.harness.charm.certificates.get_assigned_certificates()) == 0
 
-    def test_given_tls_relation_not_created_when_get_assigned_certificates_then_empty_list_returned(
+    def test_given_no_tls_relation_when_get_assigned_certificates_then_empty_list_returned(
         self,
     ):
         assert self.harness.charm.certificates.get_assigned_certificates() == []
+
+    def test_given_no_tls_relation_when_get_expiring_certificates_then_empty_list_returned(
+        self,
+    ):
+        assert self.harness.charm.certificates.get_expiring_certificates() == []
+
+    def test_given_no_tls_relation_when_get_certificate_signing_requests_then_empty_list_returned(
+        self,
+    ):
+        assert self.harness.charm.certificates.get_certificate_signing_requests() == []
 
     def test_given_csrs_created_when_get_certificate_signing_requests_then_all_csrs_returned(self):
         relation_id = self.create_certificates_relation()

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
@@ -971,6 +971,9 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
         )
 
         assert len(self.harness.charm.certificates.get_assigned_certificates()) == 0
+    
+    def test_given_tls_relation_not_created_when_get_assigned_certificates_then_empty_list_returned(self):
+        assert self.harness.charm.certificates.get_assigned_certificates() == []
 
     def test_given_csrs_created_when_get_certificate_signing_requests_then_all_csrs_returned(self):
         relation_id = self.create_certificates_relation()

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
@@ -971,8 +971,10 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
         )
 
         assert len(self.harness.charm.certificates.get_assigned_certificates()) == 0
-    
-    def test_given_tls_relation_not_created_when_get_assigned_certificates_then_empty_list_returned(self):
+
+    def test_given_tls_relation_not_created_when_get_assigned_certificates_then_empty_list_returned(
+        self,
+    ):
         assert self.harness.charm.certificates.get_assigned_certificates() == []
 
     def test_given_csrs_created_when_get_certificate_signing_requests_then_all_csrs_returned(self):


### PR DESCRIPTION
# Description

In cases where charms call public gets of the TLS Requirer and the tls relation was not created, the method would raise a Runtime error. Instead of that we now return an empty list since really, no cert has been assigned.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
