### PR TITLE
fix: replace deprecated `not_valid_after` with `not_valid_after_utc`

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -277,7 +277,7 @@ import json
 import logging
 import uuid
 from contextlib import suppress
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from ipaddress import IPv4Address
 from typing import Any, Dict, List, Literal, Optional, Union
 
@@ -307,7 +307,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 27
+LIBPATCH = 28
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -650,7 +650,7 @@ def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
     """
     try:
         certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
-        return certificate_object.not_valid_after
+        return certificate_object.not_valid_after_utc
     except ValueError:
         logger.warning("Could not load certificate.")
         return None
@@ -1937,7 +1937,7 @@ class TLSCertificatesRequiresV2(Object):
             expiry_time = _get_certificate_expiry_time(certificate_dict["certificate"])
             if not expiry_time:
                 continue
-            time_difference = expiry_time - datetime.utcnow()
+            time_difference = expiry_time - datetime.now(timezone.utc)
             if time_difference.total_seconds() < 0:
                 logger.warning("Certificate is expired")
                 self.on.certificate_invalidated.emit(

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -286,7 +286,7 @@ from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import pkcs12
-from jsonschema import exceptions, validate  # type: ignore[import-untyped]
+from jsonschema import exceptions, validate
 from ops.charm import (
     CharmBase,
     CharmEvents,
@@ -1072,7 +1072,7 @@ class CertificatesRequirerCharmEvents(CharmEvents):
 class TLSCertificatesProvidesV2(Object):
     """TLS certificates provider class to be instantiated by TLS certificates providers."""
 
-    on = CertificatesProviderCharmEvents()
+    on = CertificatesProviderCharmEvents()  # type: ignore[reportAssignmentType]
 
     def __init__(self, charm: CharmBase, relationship_name: str):
         super().__init__(charm, relationship_name)
@@ -1483,7 +1483,7 @@ class TLSCertificatesProvidesV2(Object):
 class TLSCertificatesRequiresV2(Object):
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
 
-    on = CertificatesRequirerCharmEvents()
+    on = CertificatesRequirerCharmEvents()  # type: ignore[reportAssignmentType]
 
     def __init__(
         self,

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1845,9 +1845,7 @@ class TLSCertificatesRequiresV2(Object):
         expiry_time = _get_certificate_expiry_time(certificate)
         if not expiry_time:
             return None
-        expiry_notification_time = (
-            expiry_time - timedelta(hours=self.expiry_notification_time)
-        ).replace(tzinfo=timezone.utc)
+        expiry_notification_time = expiry_time - timedelta(hours=self.expiry_notification_time)
         return _get_closest_future_time(expiry_notification_time, expiry_time)
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -641,7 +641,7 @@ def _get_closest_future_time(
     )
 
 
-def get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
+def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
     """Extract expiry time from a certificate string.
 
     Args:
@@ -1704,7 +1704,7 @@ class TLSCertificatesRequiresV2(Object):
         for csr in self.get_certificate_signing_requests(fulfilled_only=True):
             assert isinstance(csr["certificate_signing_request"], str)
             if cert := self._find_certificate_in_relation_data(csr["certificate_signing_request"]):
-                expiry_time = get_certificate_expiry_time(cert["certificate"])
+                expiry_time = _get_certificate_expiry_time(cert["certificate"])
                 if not expiry_time:
                     continue
                 expiry_notification_time = expiry_time - timedelta(
@@ -1842,7 +1842,7 @@ class TLSCertificatesRequiresV2(Object):
             Optional[datetime]: None if the certificate expiry time cannot be read,
                                 next expiry time otherwise.
         """
-        expiry_time = get_certificate_expiry_time(certificate)
+        expiry_time = _get_certificate_expiry_time(certificate)
         if not expiry_time:
             return None
         expiry_notification_time = (
@@ -1889,7 +1889,7 @@ class TLSCertificatesRequiresV2(Object):
             event.secret.remove_all_revisions()
             return
 
-        expiry_time = get_certificate_expiry_time(certificate_dict["certificate"])
+        expiry_time = _get_certificate_expiry_time(certificate_dict["certificate"])
         if not expiry_time:
             # A secret expired but matching certificate is invalid. Cleaning up
             event.secret.remove_all_revisions()
@@ -1902,7 +1902,7 @@ class TLSCertificatesRequiresV2(Object):
                 expiry=expiry_time.isoformat(),
             )
             event.secret.set_info(
-                expire=get_certificate_expiry_time(certificate_dict["certificate"]),
+                expire=_get_certificate_expiry_time(certificate_dict["certificate"]),
             )
         else:
             logger.warning("Certificate is expired")
@@ -1938,7 +1938,7 @@ class TLSCertificatesRequiresV2(Object):
             None
         """
         for certificate_dict in self._provider_certificates:
-            expiry_time = get_certificate_expiry_time(certificate_dict["certificate"])
+            expiry_time = _get_certificate_expiry_time(certificate_dict["certificate"])
             if not expiry_time:
                 continue
             time_difference = expiry_time - datetime.now(timezone.utc)

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -1809,9 +1809,7 @@ class TLSCertificatesRequiresV3(Object):
         expiry_time = _get_certificate_expiry_time(certificate)
         if not expiry_time:
             return None
-        expiry_notification_time = (
-            expiry_time - timedelta(hours=self.expiry_notification_time)
-        ).replace(tzinfo=timezone.utc)
+        expiry_notification_time = expiry_time - timedelta(hours=self.expiry_notification_time)
         return _get_closest_future_time(expiry_notification_time, expiry_time)
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -286,7 +286,7 @@ from cryptography import x509
 from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from jsonschema import exceptions, validate  # type: ignore[import-untyped]
+from jsonschema import exceptions, validate
 from ops.charm import (
     CharmBase,
     CharmEvents,
@@ -1090,7 +1090,7 @@ class CertificatesRequirerCharmEvents(CharmEvents):
 class TLSCertificatesProvidesV3(Object):
     """TLS certificates provider class to be instantiated by TLS certificates providers."""
 
-    on = CertificatesProviderCharmEvents()
+    on = CertificatesProviderCharmEvents()  # type: ignore[reportAssignmentType]
 
     def __init__(self, charm: CharmBase, relationship_name: str):
         super().__init__(charm, relationship_name)
@@ -1457,7 +1457,7 @@ class TLSCertificatesProvidesV3(Object):
 class TLSCertificatesRequiresV3(Object):
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
 
-    on = CertificatesRequirerCharmEvents()
+    on = CertificatesRequirerCharmEvents()  # type: ignore[reportAssignmentType]
 
     def __init__(
         self,

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -670,7 +670,7 @@ def _get_closest_future_time(
     )
 
 
-def get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
+def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
     """Extract expiry time from a certificate string.
 
     Args:
@@ -1694,7 +1694,7 @@ class TLSCertificatesRequiresV3(Object):
         expiring_certificates: List[ProviderCertificate] = []
         for requirer_csr in self.get_certificate_signing_requests(fulfilled_only=True):
             if cert := self._find_certificate_in_relation_data(requirer_csr.csr):
-                expiry_time = get_certificate_expiry_time(cert.certificate)
+                expiry_time = _get_certificate_expiry_time(cert.certificate)
                 if not expiry_time:
                     continue
                 expiry_notification_time = expiry_time - timedelta(
@@ -1806,7 +1806,7 @@ class TLSCertificatesRequiresV3(Object):
             Optional[datetime]: None if the certificate expiry time cannot be read,
                                 next expiry time otherwise.
         """
-        expiry_time = get_certificate_expiry_time(certificate)
+        expiry_time = _get_certificate_expiry_time(certificate)
         if not expiry_time:
             return None
         expiry_notification_time = (
@@ -1853,7 +1853,7 @@ class TLSCertificatesRequiresV3(Object):
             event.secret.remove_all_revisions()
             return
 
-        expiry_time = get_certificate_expiry_time(provider_certificate.certificate)
+        expiry_time = _get_certificate_expiry_time(provider_certificate.certificate)
         if not expiry_time:
             # A secret expired but matching certificate is invalid. Cleaning up
             event.secret.remove_all_revisions()
@@ -1866,7 +1866,7 @@ class TLSCertificatesRequiresV3(Object):
                 expiry=expiry_time.isoformat(),
             )
             event.secret.set_info(
-                expire=get_certificate_expiry_time(provider_certificate.certificate),
+                expire=_get_certificate_expiry_time(provider_certificate.certificate),
             )
         else:
             logger.warning("Certificate is expired")

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -286,7 +286,7 @@ from cryptography import x509
 from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from jsonschema import exceptions, validate  # type: ignore[import-untyped]
+from jsonschema import exceptions, validate
 from ops.charm import (
     CharmBase,
     CharmEvents,
@@ -312,7 +312,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -679,7 +679,7 @@ def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
     """
     try:
         certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
-        return certificate_object.not_valid_after
+        return certificate_object.not_valid_after_utc
     except ValueError:
         logger.warning("Could not load certificate.")
         return None

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -278,7 +278,7 @@ import logging
 import uuid
 from contextlib import suppress
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from ipaddress import IPv4Address
 from typing import List, Literal, Optional, Union
 
@@ -664,11 +664,13 @@ def _get_closest_future_time(
         datetime: expiry_notification_time if not in the past, expiry_time otherwise
     """
     return (
-        expiry_notification_time if datetime.utcnow() < expiry_notification_time else expiry_time
+        expiry_notification_time
+        if datetime.now(timezone.utc) < expiry_notification_time
+        else expiry_time
     )
 
 
-def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
+def get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
     """Extract expiry time from a certificate string.
 
     Args:
@@ -734,8 +736,8 @@ def generate_ca(
         .issuer_name(subject_name)
         .public_key(private_key_object.public_key())  # type: ignore[arg-type]
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=validity))
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
         .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
         .add_extension(
             x509.AuthorityKeyIdentifier(
@@ -889,8 +891,8 @@ def generate_certificate(
         .issuer_name(issuer)
         .public_key(csr_object.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=validity))
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
     )
     extensions = get_certificate_extensions(
         authority_key_identifier=ca_pem.extensions.get_extension_for_class(
@@ -1692,13 +1694,13 @@ class TLSCertificatesRequiresV3(Object):
         expiring_certificates: List[ProviderCertificate] = []
         for requirer_csr in self.get_certificate_signing_requests(fulfilled_only=True):
             if cert := self._find_certificate_in_relation_data(requirer_csr.csr):
-                expiry_time = _get_certificate_expiry_time(cert.certificate)
+                expiry_time = get_certificate_expiry_time(cert.certificate)
                 if not expiry_time:
                     continue
                 expiry_notification_time = expiry_time - timedelta(
                     hours=self.expiry_notification_time
                 )
-                if datetime.utcnow() > expiry_notification_time:
+                if datetime.now(timezone.utc) > expiry_notification_time:
                     expiring_certificates.append(cert)
         return expiring_certificates
 
@@ -1804,10 +1806,12 @@ class TLSCertificatesRequiresV3(Object):
             Optional[datetime]: None if the certificate expiry time cannot be read,
                                 next expiry time otherwise.
         """
-        expiry_time = _get_certificate_expiry_time(certificate)
+        expiry_time = get_certificate_expiry_time(certificate)
         if not expiry_time:
             return None
-        expiry_notification_time = expiry_time - timedelta(hours=self.expiry_notification_time)
+        expiry_notification_time = (
+            expiry_time - timedelta(hours=self.expiry_notification_time)
+        ).replace(tzinfo=timezone.utc)
         return _get_closest_future_time(expiry_notification_time, expiry_time)
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
@@ -1849,20 +1853,20 @@ class TLSCertificatesRequiresV3(Object):
             event.secret.remove_all_revisions()
             return
 
-        expiry_time = _get_certificate_expiry_time(provider_certificate.certificate)
+        expiry_time = get_certificate_expiry_time(provider_certificate.certificate)
         if not expiry_time:
             # A secret expired but matching certificate is invalid. Cleaning up
             event.secret.remove_all_revisions()
             return
 
-        if datetime.utcnow() < expiry_time:
+        if datetime.now(timezone.utc) < expiry_time:
             logger.warning("Certificate almost expired")
             self.on.certificate_expiring.emit(
                 certificate=provider_certificate.certificate,
                 expiry=expiry_time.isoformat(),
             )
             event.secret.set_info(
-                expire=_get_certificate_expiry_time(provider_certificate.certificate),
+                expire=get_certificate_expiry_time(provider_certificate.certificate),
             )
         else:
             logger.warning("Certificate is expired")

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -286,7 +286,7 @@ from cryptography import x509
 from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from jsonschema import exceptions, validate
+from jsonschema import exceptions, validate  # type: ignore[import-untyped]
 from ops.charm import (
     CharmBase,
     CharmEvents,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,4 @@ max-complexity = 10
 skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
 [tool.pyright]
-include = ["src/**.py"]
-
+include = ["src/**", "lib/**"]

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,3 @@
 cryptography
 jsonschema
-ops==2.11.0
+ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,11 +22,11 @@ pycparser==2.21
     # via cffi
 pyyaml==6.0.1
     # via ops
-referencing==0.32.1
+referencing==0.33.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==0.17.1
+rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing

--- a/tests/integration/v2/test_integration_v2.py
+++ b/tests/integration/v2/test_integration_v2.py
@@ -45,7 +45,7 @@ class TestIntegration:
         )
 
     async def test_given_charms_deployed_when_relate_then_status_is_active(self, ops_test):
-        await ops_test.model.integrate(
+        await ops_test.model.add_relation(
             relation1=TLS_CERTIFICATES_REQUIRER_APP_NAME,
             relation2=TLS_CERTIFICATES_PROVIDER_APP_NAME,
         )

--- a/tests/integration/v2/test_integration_v2.py
+++ b/tests/integration/v2/test_integration_v2.py
@@ -45,7 +45,7 @@ class TestIntegration:
         )
 
     async def test_given_charms_deployed_when_relate_then_status_is_active(self, ops_test):
-        await ops_test.model.add_relation(
+        await ops_test.model.integrate(
             relation1=TLS_CERTIFICATES_REQUIRER_APP_NAME,
             relation2=TLS_CERTIFICATES_PROVIDER_APP_NAME,
         )

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
@@ -1057,7 +1057,7 @@ class TestJuju3(unittest.TestCase):
         assert certificate_available_event.ca == ca_certificate
         assert certificate_available_event.chain == chain
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")
     def test_given_csr_in_unit_relation_data_and_certificate_in_remote_relation_data_when_relation_changed_then_secret_is_added(  # noqa: E501
         self, patch_on_certificate_available, patch_get_expiry_time
@@ -1087,7 +1087,7 @@ class TestJuju3(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() + timedelta(days=30)
+        expiry_time = datetime.now(timezone.utc) + timedelta(days=30)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1099,7 +1099,7 @@ class TestJuju3(unittest.TestCase):
         assert secret.get_content()["certificate"] == certificate
         assert secret.get_info().expires == expiry_time - timedelta(hours=168)
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")
     def test_given_csr_in_unit_relation_data_and_certificate_in_remote_relation_data_and_secret_already_exists_when_relation_changed_then_secret_is_updated(  # noqa: E501
         self, patch_on_certificate_available, patch_get_expiry_time
@@ -1134,7 +1134,7 @@ class TestJuju3(unittest.TestCase):
         )
         secret = self.harness.model.get_secret(id=secret_id)
         secret.set_info(label=f"{LIBID}-{csr}")
-        expiry_time = datetime.utcnow() + timedelta(days=30)
+        expiry_time = datetime.now(timezone.utc) + timedelta(days=30)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1411,7 +1411,7 @@ class TestJuju3(unittest.TestCase):
         )
         assert len(output) == 0
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     def test_given_no_expired_certificates_in_relation_data_when_get_expiring_certificates_then_no_certificates_returned(  # noqa: E501
         self, patch_get_expiry_time
     ):
@@ -1440,7 +1440,7 @@ class TestJuju3(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() + timedelta(weeks=520)
+        expiry_time = datetime.now(timezone.utc) + timedelta(weeks=520)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1451,7 +1451,7 @@ class TestJuju3(unittest.TestCase):
         all_certs = self.harness.charm.certificates.get_expiring_certificates()
         assert len(all_certs) == 0
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     def test_given_expired_certificate_in_relation_data_when_get_expiring_certificates_then_correct_certificates_returned(  # noqa: E501
         self, patch_get_expiry_time
     ):
@@ -1480,7 +1480,7 @@ class TestJuju3(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() + timedelta(hours=1)
+        expiry_time = datetime.now(timezone.utc) + timedelta(hours=1)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1492,7 +1492,7 @@ class TestJuju3(unittest.TestCase):
         assert len(all_certs) > 0
         assert all_certs[0]["certificate"] == certificate
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_in_relation_data_when_secret_expired_then_certificate_invalidated_event_with_reason_expired_emitted(  # noqa: E501
         self, patch_certificate_invalidated, patch_get_expiry_time
@@ -1522,7 +1522,7 @@ class TestJuju3(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() - timedelta(seconds=10)
+        expiry_time = datetime.now(timezone.utc) - timedelta(seconds=10)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1538,7 +1538,7 @@ class TestJuju3(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_and_other_certificates_in_relation_data_when_secret_expired_then_certificate_invalidated_event_with_reason_expired_emitted_once(  # noqa: E501
         self, patch_certificate_invalidated, patch_get_expiry_time
@@ -1574,7 +1574,7 @@ class TestJuju3(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() - timedelta(seconds=10)
+        expiry_time = datetime.now(timezone.utc) - timedelta(seconds=10)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1590,7 +1590,7 @@ class TestJuju3(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_in_relation_data_when_secret_expired_then_secret_revisions_are_removed(  # noqa: E501
         self, patch_certificate_invalidated, patch_get_expiry_time
@@ -1620,7 +1620,7 @@ class TestJuju3(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() - timedelta(seconds=10)
+        expiry_time = datetime.now(timezone.utc) - timedelta(seconds=10)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1635,7 +1635,7 @@ class TestJuju3(unittest.TestCase):
         with pytest.raises(RuntimeError):
             self.harness.get_secret_revisions(secret_id)
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_expiring")
     def test_given_almost_expiring_certificate_in_relation_data_when_secret_expired_then_certificate_expiring_event_emitted(  # noqa: E501
         self, patch_certificate_expiring, patch_get_expiry_time
@@ -1665,7 +1665,7 @@ class TestJuju3(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() + timedelta(days=8)
+        expiry_time = datetime.now(timezone.utc) + timedelta(days=8)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1681,7 +1681,7 @@ class TestJuju3(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_expiring")
     def test_given_almost_expiring_certificate_in_relation_data_when_secret_expired_then_secret_expiry_is_set_to_certificate_expiry(  # noqa: E501
         self, patch_certificate_expiring, patch_get_expiry_time
@@ -1711,7 +1711,7 @@ class TestJuju3(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() + timedelta(days=8)
+        expiry_time = datetime.now(timezone.utc) + timedelta(days=8)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
@@ -4,7 +4,7 @@
 
 import json
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -537,7 +537,7 @@ class TestJuju2(unittest.TestCase):
         args, _ = patch_certificate_expiring.call_args
         event_data = args[0]
         assert event_data.certificate == certificate.decode()
-        time_difference = datetime.fromisoformat(event_data.expiry) - datetime.utcnow()
+        time_difference = datetime.fromisoformat(event_data.expiry) - datetime.now(timezone.utc)
         assert (
             (hours_before_expiry * SECONDS_IN_ONE_HOUR) - 60
             <= time_difference.seconds

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_requires.py
@@ -1057,7 +1057,7 @@ class TestJuju3(unittest.TestCase):
         assert certificate_available_event.ca == ca_certificate
         assert certificate_available_event.chain == chain
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")
     def test_given_csr_in_unit_relation_data_and_certificate_in_remote_relation_data_when_relation_changed_then_secret_is_added(  # noqa: E501
         self, patch_on_certificate_available, patch_get_expiry_time
@@ -1099,7 +1099,7 @@ class TestJuju3(unittest.TestCase):
         assert secret.get_content()["certificate"] == certificate
         assert secret.get_info().expires == expiry_time - timedelta(hours=168)
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")
     def test_given_csr_in_unit_relation_data_and_certificate_in_remote_relation_data_and_secret_already_exists_when_relation_changed_then_secret_is_updated(  # noqa: E501
         self, patch_on_certificate_available, patch_get_expiry_time
@@ -1411,7 +1411,7 @@ class TestJuju3(unittest.TestCase):
         )
         assert len(output) == 0
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     def test_given_no_expired_certificates_in_relation_data_when_get_expiring_certificates_then_no_certificates_returned(  # noqa: E501
         self, patch_get_expiry_time
     ):
@@ -1451,7 +1451,7 @@ class TestJuju3(unittest.TestCase):
         all_certs = self.harness.charm.certificates.get_expiring_certificates()
         assert len(all_certs) == 0
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     def test_given_expired_certificate_in_relation_data_when_get_expiring_certificates_then_correct_certificates_returned(  # noqa: E501
         self, patch_get_expiry_time
     ):
@@ -1492,7 +1492,7 @@ class TestJuju3(unittest.TestCase):
         assert len(all_certs) > 0
         assert all_certs[0]["certificate"] == certificate
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_in_relation_data_when_secret_expired_then_certificate_invalidated_event_with_reason_expired_emitted(  # noqa: E501
         self, patch_certificate_invalidated, patch_get_expiry_time
@@ -1538,7 +1538,7 @@ class TestJuju3(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_and_other_certificates_in_relation_data_when_secret_expired_then_certificate_invalidated_event_with_reason_expired_emitted_once(  # noqa: E501
         self, patch_certificate_invalidated, patch_get_expiry_time
@@ -1590,7 +1590,7 @@ class TestJuju3(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_in_relation_data_when_secret_expired_then_secret_revisions_are_removed(  # noqa: E501
         self, patch_certificate_invalidated, patch_get_expiry_time
@@ -1635,7 +1635,7 @@ class TestJuju3(unittest.TestCase):
         with pytest.raises(RuntimeError):
             self.harness.get_secret_revisions(secret_id)
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_expiring")
     def test_given_almost_expiring_certificate_in_relation_data_when_secret_expired_then_certificate_expiring_event_emitted(  # noqa: E501
         self, patch_certificate_expiring, patch_get_expiry_time
@@ -1681,7 +1681,7 @@ class TestJuju3(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_expiring")
     def test_given_almost_expiring_certificate_in_relation_data_when_secret_expired_then_secret_expiry_is_set_to_certificate_expiry(  # noqa: E501
         self, patch_certificate_expiring, patch_get_expiry_time

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
@@ -4,7 +4,7 @@
 
 import json
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -34,7 +34,7 @@ LIB_DIR = "lib.charms.tls_certificates_interface.v3.tls_certificates"
 SECONDS_IN_ONE_HOUR = 60 * 60
 
 
-class TestTLSCertificatesRequiresV2(unittest.TestCase):
+class TestTLSCertificatesRequiresV3(unittest.TestCase):
     def setUp(self):
         self.relation_name = "certificates"
         self.remote_app = "tls-certificates-provider"
@@ -798,7 +798,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
         assert certificate_available_event.ca == ca_certificate
         assert certificate_available_event.chain == chain
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")
     def test_given_csr_in_unit_relation_data_and_certificate_in_remote_relation_data_when_relation_changed_then_secret_is_added(  # noqa: E501
         self, patch_on_certificate_available, patch_get_expiry_time
@@ -828,7 +828,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() + timedelta(days=30)
+        expiry_time = datetime.now(timezone.utc) + timedelta(days=30)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -840,7 +840,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
         assert secret.get_content()["certificate"] == certificate
         assert secret.get_info().expires == expiry_time - timedelta(hours=168)
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")
     def test_given_csr_in_unit_relation_data_and_certificate_in_remote_relation_data_and_secret_already_exists_when_relation_changed_then_secret_is_updated(  # noqa: E501
         self, patch_on_certificate_available, patch_get_expiry_time
@@ -875,7 +875,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
         )
         secret = self.harness.model.get_secret(id=secret_id)
         secret.set_info(label=f"{LIBID}-{csr}")
-        expiry_time = datetime.utcnow() + timedelta(days=30)
+        expiry_time = datetime.now(timezone.utc) + timedelta(days=30)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1167,7 +1167,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
         )
         assert len(output) == 0
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     def test_given_no_expired_certificates_in_relation_data_when_get_expiring_certificates_then_no_certificates_returned(  # noqa: E501
         self, patch_get_expiry_time
     ):
@@ -1196,7 +1196,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() + timedelta(weeks=520)
+        expiry_time = datetime.now(timezone.utc) + timedelta(weeks=520)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1207,7 +1207,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
         all_certs = self.harness.charm.certificates.get_expiring_certificates()
         assert len(all_certs) == 0
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     def test_given_expired_certificate_in_relation_data_when_get_expiring_certificates_then_correct_certificates_returned(  # noqa: E501
         self, patch_get_expiry_time
     ):
@@ -1236,7 +1236,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() + timedelta(hours=1)
+        expiry_time = datetime.now(timezone.utc) + timedelta(hours=1)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1248,7 +1248,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
         assert len(all_certs) > 0
         assert all_certs[0].certificate == certificate
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_in_relation_data_when_secret_expired_then_certificate_invalidated_event_with_reason_expired_emitted(  # noqa: E501
         self, patch_certificate_invalidated, patch_get_expiry_time
@@ -1278,7 +1278,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() - timedelta(seconds=10)
+        expiry_time = datetime.now(timezone.utc) - timedelta(seconds=10)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1294,7 +1294,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_and_other_certificates_in_relation_data_when_secret_expired_then_certificate_invalidated_event_with_reason_expired_emitted_once(  # noqa: E501
         self, patch_certificate_invalidated, patch_get_expiry_time
@@ -1330,7 +1330,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() - timedelta(seconds=10)
+        expiry_time = datetime.now(timezone.utc) - timedelta(seconds=10)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1346,7 +1346,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_in_relation_data_when_secret_expired_then_secret_revisions_are_removed(  # noqa: E501
         self, patch_certificate_invalidated, patch_get_expiry_time
@@ -1376,7 +1376,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() - timedelta(seconds=10)
+        expiry_time = datetime.now(timezone.utc) - timedelta(seconds=10)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1391,7 +1391,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
         with pytest.raises(RuntimeError):
             self.harness.get_secret_revisions(secret_id)
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_expiring")
     def test_given_almost_expiring_certificate_in_relation_data_when_secret_expired_then_certificate_expiring_event_emitted(  # noqa: E501
         self, patch_certificate_expiring, patch_get_expiry_time
@@ -1421,7 +1421,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() + timedelta(days=8)
+        expiry_time = datetime.now(timezone.utc) + timedelta(days=8)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1437,7 +1437,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_expiring")
     def test_given_almost_expiring_certificate_in_relation_data_when_secret_expired_then_secret_expiry_is_set_to_certificate_expiry(  # noqa: E501
         self, patch_certificate_expiring, patch_get_expiry_time
@@ -1467,7 +1467,7 @@ class TestTLSCertificatesRequiresV2(unittest.TestCase):
                 ]
             )
         }
-        expiry_time = datetime.utcnow() + timedelta(days=8)
+        expiry_time = datetime.now(timezone.utc) + timedelta(days=8)
         patch_get_expiry_time.return_value = expiry_time
         self.harness.update_relation_data(
             relation_id=relation_id,

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
@@ -798,7 +798,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         assert certificate_available_event.ca == ca_certificate
         assert certificate_available_event.chain == chain
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")
     def test_given_csr_in_unit_relation_data_and_certificate_in_remote_relation_data_when_relation_changed_then_secret_is_added(  # noqa: E501
         self, patch_on_certificate_available, patch_get_expiry_time
@@ -840,7 +840,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         assert secret.get_content()["certificate"] == certificate
         assert secret.get_info().expires == expiry_time - timedelta(hours=168)
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")
     def test_given_csr_in_unit_relation_data_and_certificate_in_remote_relation_data_and_secret_already_exists_when_relation_changed_then_secret_is_updated(  # noqa: E501
         self, patch_on_certificate_available, patch_get_expiry_time
@@ -1167,7 +1167,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         )
         assert len(output) == 0
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     def test_given_no_expired_certificates_in_relation_data_when_get_expiring_certificates_then_no_certificates_returned(  # noqa: E501
         self, patch_get_expiry_time
     ):
@@ -1207,7 +1207,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         all_certs = self.harness.charm.certificates.get_expiring_certificates()
         assert len(all_certs) == 0
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     def test_given_expired_certificate_in_relation_data_when_get_expiring_certificates_then_correct_certificates_returned(  # noqa: E501
         self, patch_get_expiry_time
     ):
@@ -1248,7 +1248,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         assert len(all_certs) > 0
         assert all_certs[0].certificate == certificate
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_in_relation_data_when_secret_expired_then_certificate_invalidated_event_with_reason_expired_emitted(  # noqa: E501
         self, patch_certificate_invalidated, patch_get_expiry_time
@@ -1294,7 +1294,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_and_other_certificates_in_relation_data_when_secret_expired_then_certificate_invalidated_event_with_reason_expired_emitted_once(  # noqa: E501
         self, patch_certificate_invalidated, patch_get_expiry_time
@@ -1346,7 +1346,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_in_relation_data_when_secret_expired_then_secret_revisions_are_removed(  # noqa: E501
         self, patch_certificate_invalidated, patch_get_expiry_time
@@ -1391,7 +1391,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         with pytest.raises(RuntimeError):
             self.harness.get_secret_revisions(secret_id)
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_expiring")
     def test_given_almost_expiring_certificate_in_relation_data_when_secret_expired_then_certificate_expiring_event_emitted(  # noqa: E501
         self, patch_certificate_expiring, patch_get_expiry_time
@@ -1437,7 +1437,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch(f"{LIB_DIR}.get_certificate_expiry_time")
+    @patch(f"{LIB_DIR}._get_certificate_expiry_time")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_expiring")
     def test_given_almost_expiring_certificate_in_relation_data_when_secret_expired_then_secret_expiry_is_set_to_certificate_expiry(  # noqa: E501
         self, patch_certificate_expiring, patch_get_expiry_time


### PR DESCRIPTION
# Description

Replace deprecated not_valid_after with not_valid_after_utc.

Fixes this issue:
- https://github.com/canonical/manual-tls-certificates-operator/issues/174

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
