### PR TITLE
fix: fail quickly when lib v3 is used with an unsuported Juju version

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -7,6 +7,9 @@
 This library contains the Requires and Provides classes for handling the tls-certificates
 interface.
 
+Pre-requisites:
+  - Juju >= 3.0
+
 ## Getting Started
 From a charm directory, fetch the library using `charmcraft`:
 
@@ -295,6 +298,7 @@ from ops.charm import (
     SecretExpiredEvent,
 )
 from ops.framework import EventBase, EventSource, Handle, Object
+from ops.jujuversion import JujuVersion
 from ops.model import (
     Application,
     ModelError,
@@ -312,7 +316,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1474,6 +1478,10 @@ class TLSCertificatesRequiresV3(Object):
                 Used to trigger the CertificateExpiring event. Default: 7 days.
         """
         super().__init__(charm, relationship_name)
+        if not JujuVersion.from_environ().has_secrets:
+            raise RuntimeError(
+                "This version of the TLS library requires Juju secrets (Juju >= 3.0)"
+            )
         self.relationship_name = relationship_name
         self.charm = charm
         self.expiry_notification_time = expiry_notification_time
@@ -1738,9 +1746,8 @@ class TLSCertificatesRequiresV3(Object):
         If the provider certificate is revoked, emit a CertificateInvalidateEvent,
         otherwise emit a CertificateAvailableEvent.
 
-        When Juju secrets are available, remove the secret for revoked certificate,
-        or add a secret with the correct expiry time for new certificates.
-
+        Remove the secret for revoked certificate, or add a secret with the correct expiry
+        time for new certificates.
 
         Args:
             event: Juju event

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -316,7 +316,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 PYDEPS = ["cryptography", "jsonschema"]
 

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
@@ -31,8 +31,18 @@ LIBID = "afd8c2bccf834997afce12c2706d2ede"
 LIB_DIR = "lib.charms.tls_certificates_interface.v3.tls_certificates"
 SECONDS_IN_ONE_HOUR = 60 * 60
 
+class FakeJujuVersion:
+    @classmethod
+    def from_environ(cls):
+        return cls()
+
+    @property
+    def has_secrets(self):
+        return True
 
 class TestTLSCertificatesRequiresV3(unittest.TestCase):
+
+    @patch(f"{LIB_DIR}.JujuVersion", new=FakeJujuVersion)
     def setUp(self):
         self.relation_name = "certificates"
         self.remote_app = "tls-certificates-provider"


### PR DESCRIPTION
# Description

We now fail quickly when using the lib with versions of Juju that do not support secrets. We also better document the fact that v3 of the lib only works with Juju >= 3.0.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
