### PR TITLE
fix: Uses RelationCreatedEvent instead of RelationJoinedEvent in the example requirer in the docstring

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -316,7 +316,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 PYDEPS = ["cryptography", "jsonschema"]
 

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -137,7 +137,7 @@ from charms.tls_certificates_interface.v3.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
-from ops.charm import CharmBase, RelationJoinedEvent
+from ops.charm import CharmBase, RelationCreatedEvent
 from ops.main import main
 from ops.model import ActiveStatus, WaitingStatus
 from typing import Union
@@ -151,7 +151,7 @@ class ExampleRequirerCharm(CharmBase):
         self.certificates = TLSCertificatesRequiresV3(self, "certificates")
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(
-            self.on.certificates_relation_joined, self._on_certificates_relation_joined
+            self.on.certificates_relation_created, self._on_certificates_relation_created
         )
         self.framework.observe(
             self.certificates.on.certificate_available, self._on_certificate_available
@@ -179,7 +179,7 @@ class ExampleRequirerCharm(CharmBase):
             {"private_key_password": "banana", "private_key": private_key.decode()}
         )
 
-    def _on_certificates_relation_joined(self, event: RelationJoinedEvent) -> None:
+    def _on_certificates_relation_created(self, event: RelationCreatedEvent) -> None:
         replicas_relation = self.model.get_relation("replicas")
         if not replicas_relation:
             self.unit.status = WaitingStatus("Waiting for peer relation to be created")

--- a/tests/integration/v3/requirer_charm/src/charm.py
+++ b/tests/integration/v3/requirer_charm/src/charm.py
@@ -41,7 +41,7 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
             self.certificates.on.certificate_invalidated, self._on_certificate_invalidated
         )
         self.framework.observe(
-            self.on.certificates_relation_joined, self._on_certificates_relation_joined
+            self.on.certificates_relation_created, self._on_certificates_relation_created
         )
         self.framework.observe(self.on.get_certificate_action, self._on_get_certificate_action)
 
@@ -149,7 +149,7 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
         self._generate_private_key()
         self.unit.status = BlockedStatus("Waiting for relation to be created")
 
-    def _on_certificates_relation_joined(self, event) -> None:
+    def _on_certificates_relation_created(self, event) -> None:
         self._request_certificate()
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:


### PR DESCRIPTION
# Description

Uses RelationCreatedEvent instead of RelationJoinedEvent in the example requirer in the docstring.
Fixes #144 

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
