### PR TITLE
fix: log warning instead of crashing when using with wrong juju version

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -316,7 +316,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1487,9 +1487,7 @@ class TLSCertificatesRequiresV3(Object):
         """
         super().__init__(charm, relationship_name)
         if not JujuVersion.from_environ().has_secrets:
-            raise RuntimeError(
-                "This version of the TLS library requires Juju secrets (Juju >= 3.0)"
-            )
+            logger.warning("This version of the TLS library requires Juju secrets (Juju >= 3.0)")
         self.relationship_name = relationship_name
         self.charm = charm
         self.expiry_notification_time = expiry_notification_time


### PR DESCRIPTION
# Description

PR #150 caused unit tests in every tls requirer to crash because there is no "harness" way to mention that the tests should be executed with Juju 3. This change here relaxes the behavior introduced in that PR to simply log a warning instead.

## Reference

- Matrix discussion: https://matrix.to/#/!xdClnUGkurzjxqiQcN:ubuntu.com/$9PU1wxgNUzzYKC1wL-OjfAPErt1BUJM0GmGMVrDCfAY?via=ubuntu.com&via=matrix.org&via=fsfe.org
- PR Failure: https://github.com/canonical/tls-certificates-requirer-operator/pull/87

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
