### PR TITLE
docs: require cryptography >= 42.0.0

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -19,7 +19,7 @@ charmcraft fetch-lib charms.tls_certificates_interface.v3.tls_certificates
 
 Add the following libraries to the charm's `requirements.txt` file:
 - jsonschema
-- cryptography
+- cryptography >= 42.0.0
 
 Add the following section to the charm's `charmcraft.yaml` file:
 ```yaml
@@ -316,7 +316,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["cryptography", "jsonschema"]
 


### PR DESCRIPTION
# Description

Explicitly state in documentation that the tls lib requires charms to build with cryptography >= 42.0.0 (because we use `not_valid_after_utc`).

Fixes #148 

## Reference
- https://cryptography.io/en/latest/x509/reference/#cryptography.x509.Certificate.not_valid_after_utc

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
