### PR TITLE
fix: Adds a debug log for creating secret with CSR as a label

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -316,7 +316,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1803,6 +1803,7 @@ class TLSCertificatesRequiresV3(Object):
                             expire=self._get_next_secret_expiry_time(certificate.certificate),
                         )
                     except SecretNotFoundError:
+                        logger.debug("Adding secret with label %s", f"{LIBID}-{certificate.csr}")
                         secret = self.charm.unit.add_secret(
                             {"certificate": certificate.certificate},
                             label=f"{LIBID}-{certificate.csr}",


### PR DESCRIPTION
# Description

As the [bug](https://bugs.launchpad.net/juju/+bug/2058012) we opened in Juju for secret creation issues has not been addressed yet, there was a suggestion to log the csr so when the issue comes up again we might know if it was because of the label using that csr.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
