### PR TITLE
fix: Adds more logs when creating secrets

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -1875,7 +1875,7 @@ class TLSCertificatesRequiresV3(Object):
                 if certificate.revoked:
                     with suppress(SecretNotFoundError):
                         logger.debug(
-                            "Removoing secret with label %s", f"{LIBID}-{certificate.csr}"
+                            "Removing secret with label %s", f"{LIBID}-{certificate.csr}"
                         )
                         secret = self.model.get_secret(label=f"{LIBID}-{certificate.csr}")
                         secret.remove_all_revisions()

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -317,7 +317,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1874,6 +1874,9 @@ class TLSCertificatesRequiresV3(Object):
             if certificate.csr in requirer_csrs:
                 if certificate.revoked:
                     with suppress(SecretNotFoundError):
+                        logger.debug(
+                            "Removoing secret with label %s", f"{LIBID}-{certificate.csr}"
+                        )
                         secret = self.model.get_secret(label=f"{LIBID}-{certificate.csr}")
                         secret.remove_all_revisions()
                     self.on.certificate_invalidated.emit(
@@ -1885,13 +1888,18 @@ class TLSCertificatesRequiresV3(Object):
                     )
                 else:
                     try:
+                        logger.debug(
+                            "Setting secret with label %s", f"{LIBID}-{certificate.csr}"
+                        )
                         secret = self.model.get_secret(label=f"{LIBID}-{certificate.csr}")
                         secret.set_content({"certificate": certificate.certificate})
                         secret.set_info(
                             expire=self._get_next_secret_expiry_time(certificate),
                         )
                     except SecretNotFoundError:
-                        logger.debug("Adding secret with label %s", f"{LIBID}-{certificate.csr}")
+                        logger.debug(
+                            "Creating new secret with label %s", f"{LIBID}-{certificate.csr}"
+                        )
                         secret = self.charm.unit.add_secret(
                             {"certificate": certificate.certificate},
                             label=f"{LIBID}-{certificate.csr}",


### PR DESCRIPTION
# Description

Adding more logs to debug [2058012](https://bugs.launchpad.net/juju/+bug/2058012)
Running the [CI a few times with these changes in Vault](https://github.com/canonical/vault-k8s-operator/pull/369) didn't result in the error coming up, so it could be useful to have these logs in more runs.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
