### PR TITLE
fix: csr_match_check breaks on ec private keys

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -1109,25 +1109,16 @@ def csr_matches_certificate(csr: str, cert: str) -> bool:
     Returns:
         bool: True/False depending on whether the CSR matches the certificate.
     """
-    try:
-        csr_object = x509.load_pem_x509_csr(csr.encode("utf-8"))
-        cert_object = x509.load_pem_x509_certificate(cert.encode("utf-8"))
+    csr_object = x509.load_pem_x509_csr(csr.encode("utf-8"))
+    cert_object = x509.load_pem_x509_certificate(cert.encode("utf-8"))
 
-        if csr_object.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ) != cert_object.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ):
-            return False
-        if (
-            csr_object.public_key().public_numbers().n  # type: ignore[union-attr]
-            != cert_object.public_key().public_numbers().n  # type: ignore[union-attr]
-        ):
-            return False
-    except ValueError:
-        logger.warning("Could not load certificate or CSR.")
+    if csr_object.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ) != cert_object.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ):
         return False
     return True
 

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -317,7 +317,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 PYDEPS = ["cryptography", "jsonschema"]
 

--- a/tests/unit/charms/tls_certificates_interface/v3/certificates.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/certificates.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import rsa, ec
 
 
 def generate_private_key(
@@ -39,6 +39,33 @@ def generate_private_key(
     )
     return key_bytes
 
+def generate_ec_private_key(
+        curve: Optional[ec.EllipticCurve] = ec.SECP256K1(),
+        password: Optional[bytes] = None
+) -> bytes:
+    """Generate a elliptic curve private key.
+
+    Args:
+        password (bytes): Password for decrypting the private key
+        key_size (int): Key size in bytes
+        public_exponent: Public exponent.
+
+    Returns:
+        bytes: Private Key
+    """
+    private_key = ec.generate_private_key(
+        curve=curve
+    )
+    key_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=(
+            serialization.BestAvailableEncryption(password)
+            if password
+            else serialization.NoEncryption()
+        ),
+    )
+    return key_bytes
 
 def generate_csr(
     private_key: bytes,

--- a/tests/unit/charms/tls_certificates_interface/v3/certificates.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/certificates.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa, ec
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
 
 def generate_private_key(
@@ -39,16 +39,16 @@ def generate_private_key(
     )
     return key_bytes
 
+
 def generate_ec_private_key(
-        curve: Optional[ec.EllipticCurve] = ec.SECP256K1(),
+        curve: ec.EllipticCurve = ec.SECP256K1(),
         password: Optional[bytes] = None
 ) -> bytes:
     """Generate a elliptic curve private key.
 
     Args:
+        curve (ec.EllipticCurve): The choice of EC curve to use for the private key
         password (bytes): Password for decrypting the private key
-        key_size (int): Key size in bytes
-        public_exponent: Public exponent.
 
     Returns:
         bytes: Private Key
@@ -66,6 +66,7 @@ def generate_ec_private_key(
         ),
     )
     return key_bytes
+
 
 def generate_csr(
     private_key: bytes,

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3.py
@@ -36,6 +36,7 @@ from tests.unit.charms.tls_certificates_interface.v3.certificates import (
 )
 from tests.unit.charms.tls_certificates_interface.v3.certificates import (
     generate_private_key as generate_private_key_helper,
+    generate_ec_private_key as generate_ec_private_key_helper
 )
 
 
@@ -448,6 +449,23 @@ def test_given_matching_cert_for_csr_when_csr_matches_certificate_then_it_return
     )
     assert csr_matches_certificate(csr.decode(), certificate.decode()) is True
 
+def test_given_matching_cert_for_csr_with_ec_key_when_csr_matches_certificate_then_it_returns_true():
+    private_key = generate_ec_private_key_helper()
+    csr = generate_csr_helper(
+        private_key=private_key,
+        common_name="same subject",
+    )
+    ca_key = generate_ec_private_key_helper()
+    ca = generate_ca_helper(
+        private_key=ca_key,
+        common_name="some subject",
+    )
+    certificate = generate_certificate_helper(
+        csr=csr,
+        ca=ca,
+        ca_key=generate_ec_private_key_helper(),
+    )
+    assert csr_matches_certificate(csr.decode(), certificate.decode()) is True
 
 def test_given_certificate_country_doesnt_match_with_csr_when_csr_matches_certificate_then_returns_true():  # noqa: E501
     ca_private_key = generate_private_key_helper()

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3.py
@@ -35,8 +35,10 @@ from tests.unit.charms.tls_certificates_interface.v3.certificates import (
     generate_csr as generate_csr_helper,
 )
 from tests.unit.charms.tls_certificates_interface.v3.certificates import (
+    generate_ec_private_key as generate_ec_private_key_helper,
+)
+from tests.unit.charms.tls_certificates_interface.v3.certificates import (
     generate_private_key as generate_private_key_helper,
-    generate_ec_private_key as generate_ec_private_key_helper
 )
 
 
@@ -449,7 +451,8 @@ def test_given_matching_cert_for_csr_when_csr_matches_certificate_then_it_return
     )
     assert csr_matches_certificate(csr.decode(), certificate.decode()) is True
 
-def test_given_matching_cert_for_csr_with_ec_key_when_csr_matches_certificate_then_it_returns_true():
+
+def test_given_matching_cert_for_csr_with_ec_key_when_csr_matches_certificate_then_it_returns_true():  # noqa: E501
     private_key = generate_ec_private_key_helper()
     csr = generate_csr_helper(
         private_key=private_key,
@@ -466,6 +469,7 @@ def test_given_matching_cert_for_csr_with_ec_key_when_csr_matches_certificate_th
         ca_key=generate_ec_private_key_helper(),
     )
     assert csr_matches_certificate(csr.decode(), certificate.decode()) is True
+
 
 def test_given_certificate_country_doesnt_match_with_csr_when_csr_matches_certificate_then_returns_true():  # noqa: E501
     ca_private_key = generate_private_key_helper()


### PR DESCRIPTION
# Description

This error comes from the us not handling the fact that elliptic curve keys do not have the `n` property at all. For the most part, it seems to be enough to skip the second check and just compare the public bytes only. 

Fixes [#249](https://github.com/canonical/manual-tls-certificates-operator/issues/249) (in a different repo)

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
