### PR TITLE
fix: support IPv6 address in CSR sans ip

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -277,13 +277,13 @@ juju relate <tls-certificates provider charm> <tls-certificates requirer charm>
 """  # noqa: D405, D410, D411, D214, D416
 
 import copy
+import ipaddress
 import json
 import logging
 import uuid
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from ipaddress import IPv4Address
 from typing import List, Literal, Optional, Union
 
 from cryptography import x509
@@ -317,7 +317,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 17
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1077,7 +1077,7 @@ def generate_csr(  # noqa: C901
     if sans_oid:
         _sans.extend([x509.RegisteredID(x509.ObjectIdentifier(san)) for san in sans_oid])
     if sans_ip:
-        _sans.extend([x509.IPAddress(IPv4Address(san)) for san in sans_ip])
+        _sans.extend([x509.IPAddress(ipaddress.ip_address(san)) for san in sans_ip])
     if sans:
         _sans.extend([x509.DNSName(san) for san in sans])
     if sans_dns:

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3.py
@@ -833,3 +833,21 @@ def test_given_localization_is_specified_when_generate_csr_then_csr_contains_loc
     assert csr_object.subject.get_attributes_for_oid(
         x509.NameOID.LOCALITY_NAME
         )[0].value == "Montreal"
+
+
+def test_given_ipv6_sans_when_generate_csr_then_csr_contains_ipv6_sans():
+    private_key = generate_private_key()
+
+    csr = generate_csr(
+        private_key=private_key,
+        subject="my.demo.server",
+        sans_dns=["my.demo.server"],
+        sans_ip=["2001:db8::1", "2001:db8::2"],
+    )
+
+    csr_object = x509.load_pem_x509_csr(csr)
+    sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+    sans_ip = sans.get_values_for_type(x509.IPAddress)
+    assert len(sans_ip) == 2
+    assert sans_ip[0].compressed == "2001:db8::1"
+    assert sans_ip[1].compressed == "2001:db8::2"


### PR DESCRIPTION
# Description

We assumed that the IP address received for the sans_ip was an IPv4 address. This caused an where the CSR could not be generated on systems with IPv6 addresses.  

Fixes #194 

## Logs

```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-openstack-hypervisor-0/charm/./src/charm.py", line 565, in <module>
    main(HypervisorOperatorCharm)
  File "/var/lib/juju/agents/unit-openstack-hypervisor-0/charm/venv/ops/main.py", line 544, in main
    manager.run()
  File "/var/lib/juju/agents/unit-openstack-hypervisor-0/charm/venv/ops/main.py", line 520, in run
    self._emit()
  File "/var/lib/juju/agents/unit-openstack-hypervisor-0/charm/venv/ops/main.py", line 509, in _emit
    _emit_charm_event(self.charm, self.dispatcher.event_name)
  File "/var/lib/juju/agents/unit-openstack-hypervisor-0/charm/venv/ops/main.py", line 143, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-openstack-hypervisor-0/charm/venv/ops/framework.py", line 350, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-openstack-hypervisor-0/charm/venv/ops/framework.py", line 849, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-openstack-hypervisor-0/charm/venv/ops/framework.py", line 939, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-openstack-hypervisor-0/charm/lib/ops_sunbeam/relation_handlers.py", line 965, in _on_certificates_relation_joined
    self._request_certificates()
  File "/var/lib/juju/agents/unit-openstack-hypervisor-0/charm/./src/charm.py", line 130, in _request_certificates
    csr = generate_csr(
  File "/var/lib/juju/agents/unit-openstack-hypervisor-0/charm/lib/charms/tls_certificates_interface/v1/tls_certificates.py", line 819, in generate_csr
    _sans.extend([x509.IPAddress(IPv4Address(san)) for san in sans_ip])
  File "/var/lib/juju/agents/unit-openstack-hypervisor-0/charm/lib/charms/tls_certificates_interface/v1/tls_certificates.py", line 819, in <listcomp>
    _sans.extend([x509.IPAddress(IPv4Address(san)) for san in sans_ip])
  File "/usr/lib/python3.10/ipaddress.py", line 1305, in __init__
    self._ip = self._ip_int_from_string(addr_str)
  File "/usr/lib/python3.10/ipaddress.py", line 1192, in _ip_int_from_string
    raise AddressValueError("Expected 4 octets in %r" % ip_str)
ipaddress.AddressValueError: Expected 4 octets in '2607:fea8:60a1:2300:92b1:1cff:fea2:69a8'
```
## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
