### PR TITLE
fix: ignore order of IP addresses in unit test

### DIFF
--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3.py
@@ -5,6 +5,7 @@
 import json
 import uuid
 from datetime import datetime, timedelta, timezone
+from ipaddress import IPv6Address
 from unittest.mock import Mock
 
 import pytest
@@ -849,5 +850,5 @@ def test_given_ipv6_sans_when_generate_csr_then_csr_contains_ipv6_sans():
     sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
     sans_ip = sans.get_values_for_type(x509.IPAddress)
     assert len(sans_ip) == 2
-    assert sans_ip[0].compressed == "2001:db8::1"
-    assert sans_ip[1].compressed == "2001:db8::2"
+    assert IPv6Address("2001:db8::1") in sans_ip
+    assert IPv6Address("2001:db8::2") in sans_ip


### PR DESCRIPTION
# Description

There is no guarantee that `get_values_for_type` would return that IP addresses in the same ordered as we inserted them in the certificate. This caused intermittent unit tests failures. Here we check that the value is there, regardless of its position.

Example error:
- https://github.com/canonical/tls-certificates-interface/actions/runs/9719546497/job/26829538680?pr=197#step:4:344

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
