### PR TITLE
build: Restrict the push trigger to the main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   push:
+    branches:
+      - main
 
 concurrency:
     group: ${{ github.ref == 'refs/heads/main' && format('ignore-main-{0}', github.run_id) || format('{0}-{1}', github.workflow, github.ref_name) }}


### PR DESCRIPTION
Propagating this change from times long ago: https://github.com/canonical/vault-operator/pull/85

There's no need to trigger on every push and pull_requests that merge to master, because we end up with duplicate runs on every PR.

This change will cause it to:
- Run on every change to a PR that merges to main (covered by the pull_request trigger) so that devs can validate their code works.
- Run on every commit that is merged into main (covered by the new restrictions on the push trigger) so that we validate the code still works once it is pushed, and publish things accordingly.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
