### PR TITLE
fix: Revert "chore: bump rpds-py from 0.18.0 to 0.19.1 in the pip_dependencies group"

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,4 +2,4 @@ cryptography
 jsonschema
 ops
 pydantic
-rpds-py==0.19.1
+rpds-py==0.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==0.19.1
+rpds-py==0.18.0
     # via
     #   -r requirements.in
     #   jsonschema


### PR DESCRIPTION
Reverts canonical/tls-certificates-interface#212

The PR that is being reverted was created and merged by dependabot. It was merged despite the CI failure as the build step was not added to the list of expected checks in the branch rules.
