### PR TITLE
feat: implement provider side of tls certificates v4

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -340,10 +340,10 @@ class PrivateKey:
         """Return the private key as a string."""
         return self.raw
 
-    @staticmethod
-    def from_string(private_key: str) -> "PrivateKey":
+    @classmethod
+    def from_string(cls, private_key: str) -> "PrivateKey":
         """Create a PrivateKey object from a private key."""
-        return PrivateKey(raw=private_key.strip())
+        return cls(raw=private_key.strip())
 
 
 @dataclass(frozen=True)
@@ -368,8 +368,8 @@ class Certificate:
         """Return the certificate as a string."""
         return self.raw
 
-    @staticmethod
-    def from_string(certificate: str) -> "Certificate":
+    @classmethod
+    def from_string(cls, certificate: str) -> "Certificate":
         """Create a Certificate object from a certificate."""
         try:
             certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
@@ -413,7 +413,7 @@ class Certificate:
         expiry_time = certificate_object.not_valid_after_utc
         validity_start_time = certificate_object.not_valid_before_utc
 
-        return Certificate(
+        return cls(
             raw=certificate.strip(),
             common_name=str(common_name[0].value),
             country_name=str(country_name[0].value) if country_name else None,
@@ -474,8 +474,8 @@ class CertificateSigningRequest:
             is_ca=self.is_ca,
         )
 
-    @staticmethod
-    def from_string(csr: str) -> "CertificateSigningRequest":
+    @classmethod
+    def from_string(cls, csr: str) -> "CertificateSigningRequest":
         """Create a CertificateSigningRequest object from a CSR."""
         try:
             csr_object = x509.load_pem_x509_csr(csr.encode())
@@ -500,7 +500,7 @@ class CertificateSigningRequest:
             sans_dns = ()
             sans_ip = ()
             sans_oid = ()
-        return CertificateSigningRequest(
+        return cls(
             raw=csr.strip(),
             common_name=str(common_name[0].value),
             country_name=str(country_name[0].value) if country_name else None,

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -692,8 +692,6 @@ class ProviderCertificate:
                 "ca": str(self.ca),
                 "chain": [str(cert) for cert in self.chain],
                 "revoked": self.revoked,
-                "expiry_time": self.certificate.expiry_time.isoformat(),
-                "validity_start_time": self.certificate.validity_start_time.isoformat(),
             }
         )
 

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -679,6 +679,24 @@ class ProviderCertificate:
     recommended_expiry_notification_time: Optional[int] = None
     revoked: Optional[bool] = None
 
+    def to_json(self) -> str:
+        """Return the object as a JSON string.
+
+        Returns:
+            str: JSON representation of the object
+        """
+        return json.dumps(
+            {
+                "csr": str(self.certificate_signing_request),
+                "certificate": str(self.certificate),
+                "ca": str(self.ca),
+                "chain": [str(cert) for cert in self.chain],
+                "revoked": self.revoked,
+                "expiry_time": self.certificate.expiry_time.isoformat(),
+                "validity_start_time": self.certificate.validity_start_time.isoformat(),
+            }
+        )
+
 
 @dataclass(frozen=True)
 class RequirerCSR:

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -351,9 +351,9 @@ class Certificate:
 
     raw: str
     common_name: str
-    sans_dns: Optional[List[str]] = None
-    sans_ip: Optional[List[str]] = None
-    sans_oid: Optional[List[str]] = None
+    sans_dns: Optional[Tuple[str, ...]] = None
+    sans_ip: Optional[Tuple[str, ...]] = None
+    sans_oid: Optional[Tuple[str, ...]] = None
     email_address: Optional[str] = None
     organization: Optional[str] = None
     organizational_unit: Optional[str] = None
@@ -389,25 +389,26 @@ class Certificate:
             sans = certificate_object.extensions.get_extension_for_class(
                 x509.SubjectAlternativeName
             ).value
-            sans_dns = [
+            sans_dns = tuple(
                 str(san)
                 for san in sans.get_values_for_type(x509.DNSName)
                 if isinstance(san, x509.DNSName)
-            ]
-            sans_ip = [
+            )
+            sans_ip = tuple(
                 str(san)
                 for san in sans.get_values_for_type(x509.IPAddress)
                 if isinstance(san, x509.IPAddress)
-            ]
-            sans_oid = [
+            )
+            sans_oid = tuple(
                 str(san)
                 for san in sans.get_values_for_type(x509.RegisteredID)
                 if isinstance(san, x509.RegisteredID)
-            ]
+            )
         except x509.ExtensionNotFound:
-            sans_dns = []
-            sans_ip = []
-            sans_oid = []
+            logger.debug("No SANs found in certificate")
+            sans_dns = None
+            sans_ip = None
+            sans_oid = None
         expiry_time = certificate_object.not_valid_after_utc
         validity_start_time = certificate_object.not_valid_before_utc
 
@@ -422,8 +423,8 @@ class Certificate:
             organization=str(organization_name[0].value) if organization_name else None,
             email_address=str(email_address[0].value) if email_address else None,
             sans_dns=sans_dns,
-            sans_ip=sans_ip if sans_ip else None,
-            sans_oid=sans_oid if sans_oid else None,
+            sans_ip=sans_ip,
+            sans_oid=sans_oid,
             expiry_time=expiry_time,
             validity_start_time=validity_start_time,
         )
@@ -435,9 +436,9 @@ class CertificateSigningRequest:
 
     raw: str
     common_name: str
-    sans_dns: Optional[List[str]] = None
-    sans_ip: Optional[List[str]] = None
-    sans_oid: Optional[List[str]] = None
+    sans_dns: Optional[Tuple[str, ...]] = None
+    sans_ip: Optional[Tuple[str, ...]] = None
+    sans_oid: Optional[Tuple[str, ...]] = None
     email_address: Optional[str] = None
     organization: Optional[str] = None
     organizational_unit: Optional[str] = None
@@ -490,26 +491,32 @@ class CertificateSigningRequest:
         email_address = csr_object.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
         try:
             sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
-            sans_dns = [
-                str(san)
-                for san in sans.get_values_for_type(x509.DNSName)
-                if isinstance(san, x509.DNSName)
-            ]
-            sans_ip = [
-                str(san)
-                for san in sans.get_values_for_type(x509.IPAddress)
-                if isinstance(san, x509.IPAddress)
-            ]
-            sans_oid = [
-                str(san)
-                for san in sans.get_values_for_type(x509.RegisteredID)
-                if isinstance(san, x509.RegisteredID)
-            ]
+            sans_dns = tuple(
+                [
+                    str(san)
+                    for san in sans.get_values_for_type(x509.DNSName)
+                    if isinstance(san, x509.DNSName)
+                ]
+            )
+            sans_ip = tuple(
+                [
+                    str(san)
+                    for san in sans.get_values_for_type(x509.IPAddress)
+                    if isinstance(san, x509.IPAddress)
+                ]
+            )
+            sans_oid = tuple(
+                [
+                    str(san)
+                    for san in sans.get_values_for_type(x509.RegisteredID)
+                    if isinstance(san, x509.RegisteredID)
+                ]
+            )
         except x509.ExtensionNotFound:
-            sans = []
-            sans_dns = []
-            sans_ip = []
-            sans_oid = []
+            sans = ()
+            sans_dns = ()
+            sans_ip = ()
+            sans_oid = ()
         return CertificateSigningRequest(
             raw=csr.strip(),
             common_name=str(common_name[0].value),
@@ -596,9 +603,9 @@ class CertificateRequest:
     """
 
     common_name: str
-    sans_dns: Optional[List[str]] = None
-    sans_ip: Optional[List[str]] = None
-    sans_oid: Optional[List[str]] = None
+    sans_dns: Optional[Tuple[str, ...]] = None
+    sans_ip: Optional[Tuple[str, ...]] = None
+    sans_oid: Optional[Tuple[str, ...]] = None
     email_address: Optional[str] = None
     organization: Optional[str] = None
     organizational_unit: Optional[str] = None

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -576,16 +576,7 @@ class CertificateSigningRequest:
         """
         csr_object = x509.load_pem_x509_csr(self.raw.encode("utf-8"))
         cert_object = x509.load_pem_x509_certificate(certificate.raw.encode("utf-8"))
-
-        if csr_object.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ) != cert_object.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ):
-            return False
-        return True
+        return csr_object.public_key() == cert_object.public_key()
 
     def get_sha256_hex(self) -> str:
         """Calculate the hash of the provided data and return the hexadecimal representation."""

--- a/tests/integration/v4/provider_charm/requirements.in
+++ b/tests/integration/v4/provider_charm/requirements.in
@@ -1,4 +1,3 @@
-ops
-jsonschema
 cryptography
-rpds-py==0.18.0
+ops
+pydantic

--- a/tests/integration/v4/provider_charm/requirements.txt
+++ b/tests/integration/v4/provider_charm/requirements.txt
@@ -4,32 +4,25 @@
 #
 #    pip-compile requirements.in
 #
-attrs==23.2.0
-    # via
-    #   jsonschema
-    #   referencing
+annotated-types==0.7.0
+    # via pydantic
 cffi==1.16.0
     # via cryptography
 cryptography==43.0.0
     # via -r requirements.in
-jsonschema==4.23.0
-    # via -r requirements.in
-jsonschema-specifications==2023.12.1
-    # via jsonschema
 ops==2.15.0
     # via -r requirements.in
 pycparser==2.22
     # via cffi
+pydantic==2.8.2
+    # via -r requirements.in
+pydantic-core==2.20.1
+    # via pydantic
 pyyaml==6.0.1
     # via ops
-referencing==0.35.1
+typing-extensions==4.12.2
     # via
-    #   jsonschema
-    #   jsonschema-specifications
-rpds-py==0.18.0
-    # via
-    #   -r requirements.in
-    #   jsonschema
-    #   referencing
+    #   pydantic
+    #   pydantic-core
 websocket-client==1.8.0
     # via ops

--- a/tests/integration/v4/provider_charm/src/charm.py
+++ b/tests/integration/v4/provider_charm/src/charm.py
@@ -33,7 +33,7 @@ class DummyTLSCertificatesProviderCharm(CharmBase):
         self.framework.observe(self.on.install, self._configure)
         self.framework.observe(self.on.update_status, self._configure)
         self.framework.observe(
-            self.certificates.on.certificate_creation_request,
+            self.on.certificates_relation_changed,
             self._configure,
         )
 

--- a/tests/integration/v4/provider_charm/src/charm.py
+++ b/tests/integration/v4/provider_charm/src/charm.py
@@ -74,6 +74,7 @@ class DummyTLSCertificatesProviderCharm(CharmBase):
                 )
                 self.certificates.set_relation_certificate(
                     provider_certificate=ProviderCertificate(
+                        relation_id=relation.id,
                         certificate=Certificate.from_string(certificate.decode()),
                         certificate_signing_request=certificate_request.certificate_signing_request,
                         ca=Certificate.from_string(root_certificate),
@@ -82,7 +83,6 @@ class DummyTLSCertificatesProviderCharm(CharmBase):
                             Certificate.from_string(certificate.decode()),
                         ],
                     ),
-                    relation_id=relation.id,
                 )
                 logger.info("Certificate generated and sent to requirer")
 

--- a/tests/integration/v4/provider_charm/src/charm.py
+++ b/tests/integration/v4/provider_charm/src/charm.py
@@ -5,8 +5,10 @@
 import logging
 from typing import Optional, Tuple
 
-from charms.tls_certificates_interface.v3.tls_certificates import (
-    TLSCertificatesProvidesV3,
+from charms.tls_certificates_interface.v4.tls_certificates import (
+    Certificate,
+    ProviderCertificate,
+    TLSCertificatesProvidesV4,
 )
 from ops.charm import CharmBase, CollectStatusEvent
 from ops.main import main
@@ -26,7 +28,7 @@ logger = logging.getLogger(__name__)
 class DummyTLSCertificatesProviderCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.certificates = TLSCertificatesProvidesV3(self, "certificates")
+        self.certificates = TLSCertificatesProvidesV4(self, "certificates")
         self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
         self.framework.observe(self.on.install, self._configure)
         self.framework.observe(self.on.update_status, self._configure)
@@ -67,15 +69,19 @@ class DummyTLSCertificatesProviderCharm(CharmBase):
                 certificate = generate_certificate(
                     ca=root_certificate.encode(),
                     ca_key=root_key.encode(),
-                    csr=certificate_request.csr.encode(),
+                    csr=str(certificate_request.certificate_signing_request).encode(),
                     validity=CERTIFICATE_VALIDITY,  # type: ignore
                 )
-
                 self.certificates.set_relation_certificate(
-                    certificate_signing_request=certificate_request.csr,
-                    certificate=certificate.decode(),
-                    ca=root_certificate,
-                    chain=[root_certificate, certificate.decode()],
+                    provider_certificate=ProviderCertificate(
+                        certificate=Certificate.from_string(certificate.decode()),
+                        certificate_signing_request=certificate_request.certificate_signing_request,
+                        ca=Certificate.from_string(root_certificate),
+                        chain=[
+                            Certificate.from_string(root_certificate),
+                            Certificate.from_string(certificate.decode()),
+                        ],
+                    ),
                     relation_id=relation.id,
                 )
                 logger.info("Certificate generated and sent to requirer")

--- a/tests/integration/v4/requirer_charm/src/charm.py
+++ b/tests/integration/v4/requirer_charm/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from typing import List, Optional, cast
+from typing import Optional, Tuple, cast
 
 from charms.tls_certificates_interface.v4.tls_certificates import (
     CertificateRequest,
@@ -78,9 +78,9 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
     def _get_config_common_name(self) -> str:
         return cast(str, self.model.config.get("common_name"))
 
-    def _get_config_sans_dns(self) -> List[str]:
+    def _get_config_sans_dns(self) -> Tuple[str, ...]:
         config_sans_dns = cast(str, self.model.config.get("sans_dns", ""))
-        return config_sans_dns.split(",") if config_sans_dns else []
+        return tuple(config_sans_dns.split(",") if config_sans_dns else [])
 
     def _get_config_organization_name(self) -> Optional[str]:
         return cast(str, self.model.config.get("organization_name"))

--- a/tests/integration/v4/requirer_charm/src/charm.py
+++ b/tests/integration/v4/requirer_charm/src/charm.py
@@ -50,8 +50,8 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
         event.set_results(
             {
                 "certificate": str(certificate.certificate),
-                "ca":  str(certificate.ca),
-                "chain":  str(certificate.chain),
+                "ca": str(certificate.ca),
+                "chain": str(certificate.chain),
             }
         )
 

--- a/tests/integration/v4/test_integration_v4.py
+++ b/tests/integration/v4/test_integration_v4.py
@@ -10,8 +10,7 @@ from certificates import Certificate
 
 logger = logging.getLogger(__name__)
 
-LIB_DIR_V3 = "lib/charms/tls_certificates_interface/v3/tls_certificates.py"
-LIB_DIR_V4 = "lib/charms/tls_certificates_interface/v4/tls_certificates.py"
+LIB_DIR = "lib/charms/tls_certificates_interface/v4/tls_certificates.py"
 REQUIRER_CHARM_DIR = "tests/integration/v4/requirer_charm"
 PROVIDER_CHARM_DIR = "tests/integration/v4/provider_charm"
 TLS_CERTIFICATES_PROVIDER_APP_NAME = "tls-certificates-provider"
@@ -19,8 +18,8 @@ TLS_CERTIFICATES_REQUIRER_APP_NAME = "tls-certificates-requirer"
 
 
 def copy_lib_content() -> None:
-    shutil.copyfile(src=LIB_DIR_V4, dst=f"{REQUIRER_CHARM_DIR}/{LIB_DIR_V4}")
-    shutil.copyfile(src=LIB_DIR_V3, dst=f"{PROVIDER_CHARM_DIR}/{LIB_DIR_V3}")
+    shutil.copyfile(src=LIB_DIR, dst=f"{REQUIRER_CHARM_DIR}/{LIB_DIR}")
+    shutil.copyfile(src=LIB_DIR, dst=f"{PROVIDER_CHARM_DIR}/{LIB_DIR}")
 
 
 class TestIntegration:

--- a/tests/unit/charms/tls_certificates_interface/v4/certificates.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/certificates.py
@@ -33,7 +33,7 @@ def generate_private_key(
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
     )
-    return key_bytes.decode()
+    return key_bytes.decode().strip()
 
 
 def generate_csr(
@@ -63,7 +63,7 @@ def generate_csr(
             x509.SubjectAlternativeName([x509.DNSName(san) for san in sans]), critical=False
         )
     signed_certificate = csr.sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
-    return signed_certificate.public_bytes(serialization.Encoding.PEM).decode()
+    return signed_certificate.public_bytes(serialization.Encoding.PEM).decode().strip()
 
 
 def generate_certificate(
@@ -112,7 +112,7 @@ def generate_certificate(
 
     certificate_builder._version = x509.Version.v3
     cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]
-    return cert.public_bytes(serialization.Encoding.PEM).decode()
+    return cert.public_bytes(serialization.Encoding.PEM).decode().strip()
 
 
 def generate_ca(
@@ -166,4 +166,4 @@ def generate_ca(
         )
         .sign(private_key_object, hashes.SHA256())  # type: ignore[arg-type]
     )
-    return cert.public_bytes(serialization.Encoding.PEM).decode()
+    return cert.public_bytes(serialization.Encoding.PEM).decode().strip()

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/charmcraft.yaml
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/charmcraft.yaml
@@ -1,0 +1,46 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: tls-certificates-interface-provider
+
+description: |
+  Dummy tls-certificates-interface provider.
+summary: |
+  Dummy tls-certificates-interface provider.
+
+provides:
+  certificates:
+    interface: tls-certificates
+
+actions:
+  get-certificate-requests:
+    description: Get the certificate requests from the requirers
+  get-outstanding-certificate-requests:
+    description: Get the outstanding certificate requests from the requirers
+  get-issued-certificates:
+    description: Get the issued certificates to the requirers
+  set-certificate:
+    description: Set the certificate to the requirer
+    params:
+      relation-id:
+        type: integer
+        description: >-
+          ID of the relation between the manual-tls-certificates and the requirer.
+      certificate-signing-request:
+        type: string
+        description: >-
+          The request to which the certificate is being provided.
+      certificate:
+        type: string
+        description: >-
+          Base64 encoded TLS certificate.
+      ca-chain:
+        type: string
+        description: >-
+          Base64 encoded CA chain.
+      ca-certificate:
+        type: string
+        description: >-
+          Base64 encoded CA Certificate..
+  revoke-all-certificates:
+    description: Revoke all certificates

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/src/charm.py
@@ -113,6 +113,7 @@ class DummyTLSCertificatesProviderCharm(CharmBase):
         ca_str = base64.b64decode(event.params["ca-certificate"]).decode("utf-8")
         self.certificates.set_relation_certificate(
             provider_certificate=ProviderCertificate(
+                relation_id=event.params["relation-id"],
                 certificate=Certificate.from_string(certificate_str),
                 certificate_signing_request=CertificateSigningRequest.from_string(csr_str),
                 ca=Certificate.from_string(ca_str),
@@ -120,7 +121,6 @@ class DummyTLSCertificatesProviderCharm(CharmBase):
                     Certificate.from_string(ca_certificate) for ca_certificate in ca_chain_list
                 ],
             ),
-            relation_id=event.params["relation-id"],
         )
 
     def _on_revoke_all_certificates_action(self, event: ActionEvent) -> None:

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/src/charm.py
@@ -1,0 +1,143 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import base64
+import re
+from typing import List
+
+from ops.charm import ActionEvent, CharmBase
+from ops.framework import EventBase
+from ops.main import main
+
+from lib.charms.tls_certificates_interface.v4.tls_certificates import (
+    Certificate,
+    CertificateSigningRequest,
+    ProviderCertificate,
+    TLSCertificatesProvidesV4,
+)
+
+
+def parse_ca_chain(ca_chain_pem: str) -> List[str]:
+    """Return list of certificates based on a PEM CA Chain file.
+
+    Args:
+        ca_chain_pem (str): String containing list of certificates. This string should look like:
+            -----BEGIN CERTIFICATE-----
+            <cert 1>
+            -----END CERTIFICATE-----
+            -----BEGIN CERTIFICATE-----
+            <cert 2>
+            -----END CERTIFICATE-----
+
+    Returns:
+        list: List of certificates
+    """
+    chain_list = re.findall(
+        pattern="(?=-----BEGIN CERTIFICATE-----)(.*?)(?<=-----END CERTIFICATE-----)",
+        string=ca_chain_pem,
+        flags=re.DOTALL,
+    )
+    if not chain_list:
+        raise ValueError("No certificate found in chain file")
+    return chain_list
+
+
+class DummyTLSCertificatesProviderCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.certificates = TLSCertificatesProvidesV4(self, "certificates")
+        self.framework.observe(self.on.update_status, self._configure)
+        self.framework.observe(
+            self.on.get_certificate_requests_action, self._on_get_certificate_rquests_action
+        )
+        self.framework.observe(
+            self.on.get_outstanding_certificate_requests_action,
+            self._on_get_outstanding_certificate_requests_action,
+        )
+        self.framework.observe(
+            self.on.get_issued_certificates_action, self._on_get_issued_certificates_action
+        )
+        self.framework.observe(
+            self.on.set_certificate_action,
+            self._on_set_certificate_action,
+        )
+        self.framework.observe(
+            self.on.revoke_all_certificates_action,
+            self._on_revoke_all_certificates_action,
+        )
+
+    def _configure(self, _: EventBase) -> None:
+        certificate_requests = self.certificates.get_outstanding_certificate_requests()
+        print("Certificate requests: ", certificate_requests)
+
+    def _on_get_certificate_rquests_action(self, event: ActionEvent) -> None:
+        requirer_csrs = self.certificates.get_certificate_requests()
+        csrs = []
+        for requirer_csr in requirer_csrs:
+            csrs.append(
+                {
+                    "csr": str(requirer_csr.certificate_signing_request),
+                    "is_ca": requirer_csr.certificate_signing_request.is_ca,
+                }
+            )
+        event.set_results(results={"csrs": csrs})
+
+    def _on_get_outstanding_certificate_requests_action(self, event: ActionEvent) -> None:
+        outstanding_certificate_requests = self.certificates.get_outstanding_certificate_requests()
+        certificate_requests = []
+        for outstanding_certificate_request in outstanding_certificate_requests:
+            certificate_requests.append(
+                {
+                    "csr": str(outstanding_certificate_request.certificate_signing_request),
+                    "is_ca": outstanding_certificate_request.certificate_signing_request.is_ca,
+                }
+            )
+        event.set_results(results={"csrs": certificate_requests})
+
+    def _on_get_issued_certificates_action(self, event: ActionEvent) -> None:
+        issued_certificates = self.certificates.get_issued_certificates()
+        certificates = []
+        for issued_certificate in issued_certificates:
+            certificates.append(
+                {
+                    "certificate": str(issued_certificate.certificate),
+                }
+            )
+        event.set_results(results={"certificates": certificates})
+
+    def _on_set_certificate_action(self, event: ActionEvent) -> None:
+        ca_chain_str = event.params.get("ca-chain", None)
+        ca_chain_list = parse_ca_chain(base64.b64decode(ca_chain_str).decode())
+        ca_chain = [Certificate.from_string(ca_certificate) for ca_certificate in ca_chain_list]
+        ca_chain = [ca_cert for ca_cert in ca_chain if ca_cert]
+        csr_str = base64.b64decode(event.params["certificate-signing-request"]).decode("utf-8")
+        csr = CertificateSigningRequest.from_string(csr_str)
+        if not csr:
+            event.fail("Invalid CSR")
+            return
+        certificate_str = base64.b64decode(event.params["certificate"]).decode("utf-8")
+        certificate = Certificate.from_string(certificate_str)
+        if not certificate:
+            event.fail("Invalid certificate")
+            return
+        ca_str = base64.b64decode(event.params["ca-certificate"]).decode("utf-8")
+        ca = Certificate.from_string(ca_str)
+        if not ca:
+            event.fail("Invalid CA certificate")
+            return
+        self.certificates.set_relation_certificate(
+            provider_certificate=ProviderCertificate(
+                certificate=certificate,
+                certificate_signing_request=csr,
+                ca=ca,
+                chain=[ca_cert for ca_cert in ca_chain if ca_cert],
+            ),
+            relation_id=event.params["relation-id"],
+        )
+
+    def _on_revoke_all_certificates_action(self, event: ActionEvent) -> None:
+        self.certificates.revoke_all_certificates()
+
+
+if __name__ == "__main__":
+    main(DummyTLSCertificatesProviderCharm)

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/src/charm.py
@@ -108,29 +108,17 @@ class DummyTLSCertificatesProviderCharm(CharmBase):
     def _on_set_certificate_action(self, event: ActionEvent) -> None:
         ca_chain_str = event.params.get("ca-chain", None)
         ca_chain_list = parse_ca_chain(base64.b64decode(ca_chain_str).decode())
-        ca_chain = [Certificate.from_string(ca_certificate) for ca_certificate in ca_chain_list]
-        ca_chain = [ca_cert for ca_cert in ca_chain if ca_cert]
         csr_str = base64.b64decode(event.params["certificate-signing-request"]).decode("utf-8")
-        csr = CertificateSigningRequest.from_string(csr_str)
-        if not csr:
-            event.fail("Invalid CSR")
-            return
         certificate_str = base64.b64decode(event.params["certificate"]).decode("utf-8")
-        certificate = Certificate.from_string(certificate_str)
-        if not certificate:
-            event.fail("Invalid certificate")
-            return
         ca_str = base64.b64decode(event.params["ca-certificate"]).decode("utf-8")
-        ca = Certificate.from_string(ca_str)
-        if not ca:
-            event.fail("Invalid CA certificate")
-            return
         self.certificates.set_relation_certificate(
             provider_certificate=ProviderCertificate(
-                certificate=certificate,
-                certificate_signing_request=csr,
-                ca=ca,
-                chain=[ca_cert for ca_cert in ca_chain if ca_cert],
+                certificate=Certificate.from_string(certificate_str),
+                certificate_signing_request=CertificateSigningRequest.from_string(csr_str),
+                ca=Certificate.from_string(ca_str),
+                chain=[
+                    Certificate.from_string(ca_certificate) for ca_certificate in ca_chain_list
+                ],
             ),
             relation_id=event.params["relation-id"],
         )

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from typing import List, Optional, cast
+from typing import List, Optional, Tuple, cast
 
 from ops.charm import ActionEvent, CharmBase
 from ops.main import main
@@ -76,9 +76,9 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
     def _get_config_common_name(self) -> str:
         return cast(str, self.model.config.get("common_name"))
 
-    def _get_config_sans_dns(self) -> List[str]:
+    def _get_config_sans_dns(self) -> Tuple[str, ...]:
         config_sans_dns = cast(str, self.model.config.get("sans_dns", ""))
-        return config_sans_dns.split(",") if config_sans_dns else []
+        return tuple(config_sans_dns.split(",") if config_sans_dns else [])
 
     def _get_config_organization_name(self) -> Optional[str]:
         return cast(str, self.model.config.get("organization_name"))

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
@@ -197,8 +197,7 @@ class TestCertificateRequest:
 
         certificate_request = CertificateRequest(
             common_name="my.demo.server",
-            sans_dns=["my.demo.server"],
-            sans_ip=[],
+            sans_dns=tuple("my.demo.server"),
             country_name="CA",
             state_or_province_name="Quebec",
             locality_name="Montreal",
@@ -224,8 +223,8 @@ class TestCertificateRequest:
 
         certificate_request = CertificateRequest(
             common_name="my.demo.server",
-            sans_dns=["my.demo.server"],
-            sans_ip=["2001:db8::1", "2001:db8::2"],
+            sans_dns=tuple("my.demo.server"),
+            sans_ip=("2001:db8::1", "2001:db8::2"),
         )
 
         csr = certificate_request.generate_csr(private_key=private_key)

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_provides.py
@@ -1,0 +1,700 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+import scenario
+import yaml
+
+from tests.unit.charms.tls_certificates_interface.v4.certificates import (
+    generate_ca,
+    generate_certificate,
+    generate_csr,
+    generate_private_key,
+)
+from tests.unit.charms.tls_certificates_interface.v4.dummy_provider_charm.src.charm import (
+    DummyTLSCertificatesProviderCharm,
+)
+
+METADATA = yaml.safe_load(
+    Path(
+        "tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/charmcraft.yaml"  # noqa: E501
+    ).read_text()
+)
+
+
+class TestTLSCertificatesProvidesV4:
+    @pytest.fixture(autouse=True)
+    def context(self):
+        self.ctx = scenario.Context(
+            charm_type=DummyTLSCertificatesProviderCharm,
+            meta=METADATA,
+            actions=METADATA["actions"],
+        )
+
+    def test_given_no_certificate_requests_when_get_requirer_csrs_then_no_csrs_are_returned(  # noqa: E501
+        self,
+    ):
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+        )
+        state_in = scenario.State(
+            relations=[certificates_relation],
+            leader=True,
+        )
+
+        action_output = self.ctx.run_action("get-certificate-requests", state_in)
+
+        assert action_output.success is True
+        assert action_output.results == {"csrs": []}
+
+    def test_given_unit_certificate_requests_when_get_requirer_csrs_then_csrs_are_returned(self):
+        private_key = generate_private_key()
+        csr_1 = generate_csr(
+            private_key=private_key,
+            common_name="example.com",
+        )
+        csr_2 = generate_csr(
+            private_key=private_key,
+            common_name="example.org",
+        )
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+            remote_units_data={
+                0: {
+                    "certificate_signing_requests": json.dumps(
+                        [
+                            {
+                                "certificate_signing_request": csr_1,
+                                "ca": "false",
+                            },
+                            {
+                                "certificate_signing_request": csr_2,
+                                "ca": "false",
+                            },
+                        ]
+                    )
+                }
+            },
+        )
+
+        state_in = scenario.State(
+            relations=[certificates_relation],
+            leader=True,
+        )
+
+        action_output = self.ctx.run_action("get-certificate-requests", state_in)
+
+        assert action_output.success is True
+        assert action_output.results == {
+            "csrs": [{"csr": csr_1, "is_ca": False}, {"csr": csr_2, "is_ca": False}]
+        }
+
+    def test_given_app_certificate_requests_when_get_requirer_csrs_then_csrs_are_returned(self):
+        private_key = generate_private_key()
+        csr_1 = generate_csr(
+            private_key=private_key,
+            common_name="example.com",
+        )
+        csr_2 = generate_csr(
+            private_key=private_key,
+            common_name="example.org",
+        )
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+            remote_app_data={
+                "certificate_signing_requests": json.dumps(
+                    [
+                        {
+                            "certificate_signing_request": csr_1,
+                            "ca": "false",
+                        },
+                        {
+                            "certificate_signing_request": csr_2,
+                            "ca": "false",
+                        },
+                    ]
+                )
+            },
+        )
+
+        state_in = scenario.State(
+            relations=[certificates_relation],
+            leader=True,
+        )
+
+        action_output = self.ctx.run_action("get-certificate-requests", state_in)
+
+        assert action_output.success is True
+        assert action_output.results == {
+            "csrs": [{"csr": csr_1, "is_ca": False}, {"csr": csr_2, "is_ca": False}]
+        }
+
+    def test_given_no_certificate_when_get_issued_certificates_then_no_certificate_is_returned(
+        self,
+    ):
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+        )
+        state_in = scenario.State(
+            relations=[certificates_relation],
+            leader=True,
+        )
+
+        action_output = self.ctx.run_action("get-issued-certificates", state_in)
+
+        assert action_output.success is True
+        assert action_output.results == {"certificates": []}
+
+    def test_given_no_request_when_get_outstanding_certificate_requests_then_no_csr_is_returned(
+        self,
+    ):
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+        )
+        state_in = scenario.State(
+            relations=[certificates_relation],
+            leader=True,
+        )
+
+        action_output = self.ctx.run_action("get-outstanding-certificate-requests", state_in)
+
+        assert action_output.success is True
+        assert action_output.results == {"csrs": []}
+
+    def test_given_certificate_requests_fulfilled_when_get_outstanding_certificate_requests_then_no_csr_is_returned(  # noqa: E501
+        self,
+    ):
+        requirer_private_key = generate_private_key()
+        csr_1 = generate_csr(
+            private_key=requirer_private_key,
+            common_name="example1.com",
+        )
+        csr_2 = generate_csr(
+            private_key=requirer_private_key,
+            common_name="example2.org",
+        )
+        provider_private_key = generate_private_key()
+        provider_ca_certificate = generate_ca(
+            private_key=provider_private_key,
+            common_name="example.com",
+        )
+        certificate_1 = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr_1,
+            ca=provider_ca_certificate,
+        )
+        certificate_2 = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr_2,
+            ca=provider_ca_certificate,
+        )
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+            local_app_data={
+                "certificates": json.dumps(
+                    [
+                        {
+                            "certificate": certificate_1,
+                            "certificate_signing_request": csr_1,
+                            "ca": provider_ca_certificate,
+                        },
+                        {
+                            "certificate": certificate_2,
+                            "certificate_signing_request": csr_2,
+                            "ca": provider_ca_certificate,
+                        },
+                    ]
+                ),
+            },
+            remote_app_data={
+                "certificate_signing_requests": json.dumps(
+                    [
+                        {
+                            "certificate_signing_request": csr_1,
+                            "ca": "false",
+                        }
+                    ]
+                ),
+            },
+            remote_units_data={
+                0: {
+                    "certificate_signing_requests": json.dumps(
+                        [
+                            {
+                                "certificate_signing_request": csr_2,
+                                "ca": "false",
+                            },
+                        ]
+                    )
+                }
+            },
+        )
+
+        state_in = scenario.State(
+            relations=[certificates_relation],
+            leader=True,
+        )
+
+        action_output = self.ctx.run_action("get-outstanding-certificate-requests", state_in)
+
+        assert action_output.success is True
+        assert action_output.results == {"csrs": []}
+
+    def test_given_unfilfilled_certificate_request_when_get_outstanding_certificate_requests_then_csr_is_returned(  # noqa: E501
+        self,
+    ):
+        requirer_private_key = generate_private_key()
+        csr_1 = generate_csr(
+            private_key=requirer_private_key,
+            common_name="example1.com",
+        )
+        csr_2 = generate_csr(
+            private_key=requirer_private_key,
+            common_name="example2.org",
+        )
+        provider_private_key = generate_private_key()
+        provider_ca_certificate = generate_ca(
+            private_key=provider_private_key,
+            common_name="example.com",
+        )
+        certificate_1 = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr_1,
+            ca=provider_ca_certificate,
+        )
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+            local_app_data={
+                "certificates": json.dumps(
+                    [
+                        {
+                            "certificate": certificate_1,
+                            "certificate_signing_request": csr_1,
+                            "ca": provider_ca_certificate,
+                        },
+                    ]
+                ),
+            },
+            remote_app_data={
+                "certificate_signing_requests": json.dumps(
+                    [
+                        {
+                            "certificate_signing_request": csr_1,
+                            "ca": "false",
+                        }
+                    ]
+                ),
+            },
+            remote_units_data={
+                0: {
+                    "certificate_signing_requests": json.dumps(
+                        [
+                            {
+                                "certificate_signing_request": csr_2,
+                                "ca": "false",
+                            },
+                        ]
+                    )
+                }
+            },
+        )
+
+        state_in = scenario.State(
+            relations=[certificates_relation],
+            leader=True,
+        )
+
+        action_output = self.ctx.run_action("get-outstanding-certificate-requests", state_in)
+
+        assert action_output.success is True
+        assert action_output.results == {"csrs": [{"csr": csr_2, "is_ca": False}]}
+
+    def test_given_certificates_when_get_issued_certificates_then_certificates_are_returned(self):
+        requirer_private_key = generate_private_key()
+        csr_1 = generate_csr(
+            private_key=requirer_private_key,
+            common_name="example1.com",
+        )
+        csr_2 = generate_csr(
+            private_key=requirer_private_key,
+            common_name="example2.org",
+        )
+        provider_private_key = generate_private_key()
+        provider_ca_certificate = generate_ca(
+            private_key=provider_private_key,
+            common_name="example.com",
+        )
+        certificate_1 = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr_1,
+            ca=provider_ca_certificate,
+        )
+        certificate_2 = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr_2,
+            ca=provider_ca_certificate,
+        )
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+            local_app_data={
+                "certificates": json.dumps(
+                    [
+                        {
+                            "certificate": certificate_1,
+                            "certificate_signing_request": csr_1,
+                            "ca": provider_ca_certificate,
+                        },
+                        {
+                            "certificate": certificate_2,
+                            "certificate_signing_request": csr_2,
+                            "ca": provider_ca_certificate,
+                        },
+                    ]
+                ),
+            },
+        )
+
+        state_in = scenario.State(
+            relations=[certificates_relation],
+            leader=True,
+        )
+
+        action_output = self.ctx.run_action("get-issued-certificates", state_in)
+
+        assert action_output.success is True
+        assert action_output.results == {
+            "certificates": [{"certificate": certificate_1}, {"certificate": certificate_2}]
+        }
+
+    def test_given_certificate_request_when_set_relation_certificate_then_certificate_added_to_relation_data(  # noqa: E501
+        self,
+    ):
+        requirer_private_key = generate_private_key()
+        csr_1 = generate_csr(
+            private_key=requirer_private_key,
+            common_name="example1.com",
+        )
+        csr_2 = generate_csr(
+            private_key=requirer_private_key,
+            common_name="example2.org",
+        )
+        provider_private_key = generate_private_key()
+        provider_ca_certificate = generate_ca(
+            private_key=provider_private_key,
+            common_name="example.com",
+        )
+        certificate_1 = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr_1,
+            ca=provider_ca_certificate,
+        )
+        certificate_2 = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr_2,
+            ca=provider_ca_certificate,
+        )
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+            local_app_data={
+                "certificates": json.dumps(
+                    [
+                        {
+                            "certificate": certificate_1,
+                            "certificate_signing_request": csr_1,
+                            "ca": provider_ca_certificate,
+                            "chain": [provider_ca_certificate],
+                        }
+                    ]
+                ),
+            },
+            remote_app_data={
+                "certificate_signing_requests": json.dumps(
+                    [
+                        {
+                            "certificate_signing_request": csr_1,
+                            "ca": "false",
+                        }
+                    ]
+                ),
+            },
+            remote_units_data={
+                0: {
+                    "certificate_signing_requests": json.dumps(
+                        [
+                            {
+                                "certificate_signing_request": csr_2,
+                                "ca": "false",
+                            },
+                        ]
+                    )
+                }
+            },
+        )
+
+        state_in = scenario.State(
+            relations=[certificates_relation],
+            leader=True,
+        )
+        action = scenario.Action(
+            "set-certificate",
+            params={
+                "certificate": base64.b64encode(certificate_2.encode()).decode(),
+                "certificate-signing-request": base64.b64encode(csr_2.encode()).decode(),
+                "ca-certificate": base64.b64encode(provider_ca_certificate.encode()).decode(),
+                "ca-chain": base64.b64encode(provider_ca_certificate.encode()).decode(),
+                "relation-id": certificates_relation.relation_id,
+            },
+        )
+        action_output = self.ctx.run_action(action, state_in)
+
+        assert action_output.success is True
+        certificates = json.loads(action_output.state.relations[0].local_app_data["certificates"])
+        assert certificates == [
+            {
+                "certificate": certificate_1,
+                "certificate_signing_request": csr_1,
+                "ca": provider_ca_certificate,
+                "chain": [provider_ca_certificate],
+            },
+            {
+                "certificate": certificate_2,
+                "certificate_signing_request": csr_2,
+                "ca": provider_ca_certificate,
+                "chain": [provider_ca_certificate],
+            },
+        ]
+
+    def test_given_certificate_exists_for_request_when_set_relation_certificate_then_request_is_overwritten(  # noqa: E501
+        self,
+    ):
+        requirer_private_key = generate_private_key()
+        csr_1 = generate_csr(
+            private_key=requirer_private_key,
+            common_name="example1.com",
+        )
+        csr_2 = generate_csr(
+            private_key=requirer_private_key,
+            common_name="example2.org",
+        )
+        provider_private_key = generate_private_key()
+        provider_ca_certificate = generate_ca(
+            private_key=provider_private_key,
+            common_name="example.com",
+        )
+        certificate_1 = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr_1,
+            ca=provider_ca_certificate,
+        )
+        certificate_2 = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr_2,
+            ca=provider_ca_certificate,
+        )
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+            local_app_data={
+                "certificates": json.dumps(
+                    [
+                        {
+                            "certificate": certificate_1,
+                            "certificate_signing_request": csr_1,
+                            "ca": provider_ca_certificate,
+                            "chain": [provider_ca_certificate],
+                        },
+                        {
+                            "certificate": certificate_2,
+                            "certificate_signing_request": csr_2,
+                            "ca": provider_ca_certificate,
+                            "chain": [provider_ca_certificate],
+                        },
+                    ]
+                ),
+            },
+            remote_app_data={
+                "certificate_signing_requests": json.dumps(
+                    [
+                        {
+                            "certificate_signing_request": csr_1,
+                            "ca": "false",
+                        }
+                    ]
+                ),
+            },
+            remote_units_data={
+                0: {
+                    "certificate_signing_requests": json.dumps(
+                        [
+                            {
+                                "certificate_signing_request": csr_2,
+                                "ca": "false",
+                            },
+                        ]
+                    )
+                }
+            },
+        )
+
+        new_certificate_for_csr_1 = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr_1,
+            ca=provider_ca_certificate,
+        )
+
+        state_in = scenario.State(
+            relations=[certificates_relation],
+            leader=True,
+        )
+
+        action = scenario.Action(
+            "set-certificate",
+            params={
+                "certificate": base64.b64encode(new_certificate_for_csr_1.encode()).decode(),
+                "certificate-signing-request": base64.b64encode(csr_1.encode()).decode(),
+                "ca-certificate": base64.b64encode(provider_ca_certificate.encode()).decode(),
+                "ca-chain": base64.b64encode(provider_ca_certificate.encode()).decode(),
+                "relation-id": certificates_relation.relation_id,
+            },
+        )
+
+        action_output = self.ctx.run_action(action, state_in)
+
+        assert action_output.success is True
+        certificates = json.loads(action_output.state.relations[0].local_app_data["certificates"])
+        assert certificates == [
+            {
+                "certificate": certificate_2,
+                "certificate_signing_request": csr_2,
+                "ca": provider_ca_certificate,
+                "chain": [provider_ca_certificate],
+            },
+            {
+                "certificate": new_certificate_for_csr_1,
+                "certificate_signing_request": csr_1,
+                "ca": provider_ca_certificate,
+                "chain": [provider_ca_certificate],
+            },
+        ]
+
+    def test_given_certificates_when_revoke_all_certificates_then_certificates_are_revoked(self):
+        requirer_private_key = generate_private_key()
+        csr_1 = generate_csr(
+            private_key=requirer_private_key,
+            common_name="example1.com",
+        )
+        csr_2 = generate_csr(
+            private_key=requirer_private_key,
+            common_name="example2.org",
+        )
+        provider_private_key = generate_private_key()
+        provider_ca_certificate = generate_ca(
+            private_key=provider_private_key,
+            common_name="example.com",
+        )
+        certificate_1 = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr_1,
+            ca=provider_ca_certificate,
+        )
+        certificate_2 = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr_2,
+            ca=provider_ca_certificate,
+        )
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+            local_app_data={
+                "certificates": json.dumps(
+                    [
+                        {
+                            "certificate": certificate_1,
+                            "certificate_signing_request": csr_1,
+                            "ca": provider_ca_certificate,
+                            "chain": [provider_ca_certificate],
+                        },
+                        {
+                            "certificate": certificate_2,
+                            "certificate_signing_request": csr_2,
+                            "ca": provider_ca_certificate,
+                            "chain": [provider_ca_certificate],
+                        },
+                    ]
+                ),
+            },
+            remote_app_data={
+                "certificate_signing_requests": json.dumps(
+                    [
+                        {
+                            "certificate_signing_request": csr_1,
+                            "ca": "false",
+                        }
+                    ]
+                ),
+            },
+            remote_units_data={
+                0: {
+                    "certificate_signing_requests": json.dumps(
+                        [
+                            {
+                                "certificate_signing_request": csr_2,
+                                "ca": "false",
+                            },
+                        ]
+                    )
+                }
+            },
+        )
+
+        state_in = scenario.State(
+            relations=[certificates_relation],
+            leader=True,
+        )
+
+        action_output = self.ctx.run_action("revoke-all-certificates", state_in)
+
+        assert action_output.success is True
+
+        certificates = json.loads(action_output.state.relations[0].local_app_data["certificates"])
+
+        assert certificates == [
+            {
+                "certificate": certificate_1,
+                "certificate_signing_request": csr_1,
+                "ca": provider_ca_certificate,
+                "chain": [provider_ca_certificate],
+                "revoked": True,
+            },
+            {
+                "certificate": certificate_2,
+                "certificate_signing_request": csr_2,
+                "ca": provider_ca_certificate,
+                "chain": [provider_ca_certificate],
+                "revoked": True,
+            },
+        ]

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_provides.py
@@ -256,7 +256,7 @@ class TestTLSCertificatesProvidesV4:
         assert action_output.success is True
         assert action_output.results == {"csrs": []}
 
-    def test_given_unfilfilled_certificate_request_when_get_outstanding_certificate_requests_then_csr_is_returned(  # noqa: E501
+    def test_given_unfulfilled_certificate_request_when_get_outstanding_certificate_requests_then_csr_is_returned(  # noqa: E501
         self,
     ):
         requirer_private_key = generate_private_key()

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 import datetime
 import json
 from pathlib import Path

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
@@ -131,7 +131,7 @@ class TestTLSCertificatesRequiresV4:
                     "certificate_signing_requests": json.dumps(
                         [
                             {
-                                "certificate_signing_request": csr.strip(),
+                                "certificate_signing_request": csr,
                                 "ca": False,
                             }
                         ]
@@ -166,7 +166,7 @@ class TestTLSCertificatesRequiresV4:
                 "certificate_signing_requests": json.dumps(
                     [
                         {
-                            "certificate_signing_request": csr.strip(),
+                            "certificate_signing_request": csr,
                             "ca": False,
                         }
                     ]
@@ -176,9 +176,9 @@ class TestTLSCertificatesRequiresV4:
                 "certificates": json.dumps(
                     [
                         {
-                            "certificate": certificate.strip(),
-                            "certificate_signing_request": csr.strip(),
-                            "ca": provider_ca_certificate.strip(),
+                            "certificate": certificate,
+                            "certificate_signing_request": csr,
+                            "ca": provider_ca_certificate,
                         }
                     ]
                 ),
@@ -203,7 +203,7 @@ class TestTLSCertificatesRequiresV4:
         assert len(self.ctx.emitted_events) == 2
         assert isinstance(self.ctx.emitted_events[1], CertificateAvailableEvent)
         assert self.ctx.emitted_events[1].certificate == Certificate.from_string(
-            certificate.strip()
+            certificate
         )
         assert self.ctx.emitted_events[1].ca == Certificate.from_string(provider_ca_certificate)
         assert self.ctx.emitted_events[
@@ -236,8 +236,8 @@ class TestTLSCertificatesRequiresV4:
                 "certificates": json.dumps(
                     [
                         {
-                            "certificate": certificate.strip(),
-                            "ca": provider_ca_certificate.strip(),
+                            "certificate": certificate,
+                            "ca": provider_ca_certificate,
                         }
                     ]
                 ),
@@ -269,7 +269,7 @@ class TestTLSCertificatesRequiresV4:
                 "certificate_signing_requests": json.dumps(
                     [
                         {
-                            "certificate_signing_request": csr.strip(),
+                            "certificate_signing_request": csr,
                             "ca": False,
                         }
                     ]
@@ -312,7 +312,7 @@ class TestTLSCertificatesRequiresV4:
                 "certificate_signing_requests": json.dumps(
                     [
                         {
-                            "certificate_signing_request": csr.strip(),
+                            "certificate_signing_request": csr,
                             "ca": False,
                         }
                     ]
@@ -354,7 +354,7 @@ class TestTLSCertificatesRequiresV4:
                     "certificate_signing_requests": json.dumps(
                         [
                             {
-                                "certificate_signing_request": new_csr.strip(),
+                                "certificate_signing_request": new_csr,
                                 "ca": False,
                             }
                         ]
@@ -385,7 +385,7 @@ class TestTLSCertificatesRequiresV4:
                 "certificate_signing_requests": json.dumps(
                     [
                         {
-                            "certificate_signing_request": csr_in_relation_data.strip(),
+                            "certificate_signing_request": csr_in_relation_data,
                             "ca": False,
                         }
                     ]
@@ -419,7 +419,7 @@ class TestTLSCertificatesRequiresV4:
                     "certificate_signing_requests": json.dumps(
                         [
                             {
-                                "certificate_signing_request": new_csr.strip(),
+                                "certificate_signing_request": new_csr,
                                 "ca": False,
                             }
                         ]
@@ -454,7 +454,7 @@ class TestTLSCertificatesRequiresV4:
                 "certificate_signing_requests": json.dumps(
                     [
                         {
-                            "certificate_signing_request": csr.strip(),
+                            "certificate_signing_request": csr,
                             "ca": False,
                         }
                     ]
@@ -464,9 +464,9 @@ class TestTLSCertificatesRequiresV4:
                 "certificates": json.dumps(
                     [
                         {
-                            "certificate": certificate.strip(),
-                            "certificate_signing_request": csr.strip(),
-                            "ca": provider_ca_certificate.strip(),
+                            "certificate": certificate,
+                            "certificate_signing_request": csr,
+                            "ca": provider_ca_certificate,
                             "revoked": True,
                         }
                     ]
@@ -485,7 +485,7 @@ class TestTLSCertificatesRequiresV4:
         certificate_secret = Secret(
             id="1",
             revision=0,
-            label=f"{LIBID}-certificate-0-{get_sha256_hex(csr.strip())}",
+            label=f"{LIBID}-certificate-0-{get_sha256_hex(csr)}",
             owner="unit",
             contents={
                 0: {
@@ -510,7 +510,7 @@ class TestTLSCertificatesRequiresV4:
             Secret(
                 id="1",
                 revision=0,
-                label=f"{LIBID}-certificate-0-{get_sha256_hex(csr.strip())}",
+                label=f"{LIBID}-certificate-0-{get_sha256_hex(csr)}",
                 owner="unit",
                 contents={},
             ),
@@ -570,7 +570,7 @@ class TestTLSCertificatesRequiresV4:
                 "certificate_signing_requests": json.dumps(
                     [
                         {
-                            "certificate_signing_request": csr.strip(),
+                            "certificate_signing_request": csr,
                             "ca": False,
                         }
                     ]
@@ -580,9 +580,9 @@ class TestTLSCertificatesRequiresV4:
                 "certificates": json.dumps(
                     [
                         {
-                            "certificate": certificate.strip(),
-                            "certificate_signing_request": csr.strip(),
-                            "ca": provider_ca_certificate.strip(),
+                            "certificate": certificate,
+                            "certificate_signing_request": csr,
+                            "ca": provider_ca_certificate,
                         }
                     ]
                 ),
@@ -598,9 +598,9 @@ class TestTLSCertificatesRequiresV4:
 
         assert action_output.success is True
         assert action_output.results == {
-            "certificate": certificate.strip(),
-            "ca": provider_ca_certificate.strip(),
-            "csr": csr.strip(),
+            "certificate": certificate,
+            "ca": provider_ca_certificate,
+            "csr": csr,
         }
 
     def test_given_certificate_is_provided_when_relation_changed_then_certificate_secret_is_created(  # noqa: E501
@@ -629,7 +629,7 @@ class TestTLSCertificatesRequiresV4:
                 "certificate_signing_requests": json.dumps(
                     [
                         {
-                            "certificate_signing_request": csr.strip(),
+                            "certificate_signing_request": csr,
                             "ca": False,
                         }
                     ]
@@ -639,9 +639,9 @@ class TestTLSCertificatesRequiresV4:
                 "certificates": json.dumps(
                     [
                         {
-                            "certificate": certificate.strip(),
-                            "certificate_signing_request": csr.strip(),
-                            "ca": provider_ca_certificate.strip(),
+                            "certificate": certificate,
+                            "certificate_signing_request": csr,
+                            "ca": provider_ca_certificate,
                         }
                     ]
                 ),
@@ -678,12 +678,12 @@ class TestTLSCertificatesRequiresV4:
         initial_certificate_secret = Secret(
             id="1",
             revision=0,
-            label=f"{LIBID}-certificate-0-{get_sha256_hex(csr.strip())}",
+            label=f"{LIBID}-certificate-0-{get_sha256_hex(csr)}",
             owner="unit",
             contents={
                 0: {
                     "certificate": "initial certificate",
-                    "csr": csr.strip(),
+                    "csr": csr,
                 }
             },
         )
@@ -706,7 +706,7 @@ class TestTLSCertificatesRequiresV4:
                 "certificate_signing_requests": json.dumps(
                     [
                         {
-                            "certificate_signing_request": csr.strip(),
+                            "certificate_signing_request": csr,
                             "ca": False,
                         }
                     ]
@@ -716,9 +716,9 @@ class TestTLSCertificatesRequiresV4:
                 "certificates": json.dumps(
                     [
                         {
-                            "certificate": new_certificate.strip(),
-                            "certificate_signing_request": csr.strip(),
-                            "ca": provider_ca_certificate.strip(),
+                            "certificate": new_certificate,
+                            "certificate_signing_request": csr,
+                            "ca": provider_ca_certificate,
                         }
                     ]
                 ),
@@ -730,7 +730,7 @@ class TestTLSCertificatesRequiresV4:
             revision=0,
             label=f"{LIBID}-private-key-0",
             owner="unit",
-            contents={0: {"private-key": private_key.strip()}},
+            contents={0: {"private-key": private_key}},
         )
 
         state_in = scenario.State(
@@ -746,8 +746,8 @@ class TestTLSCertificatesRequiresV4:
         certificate_secret = self.get_certificate_secret(state_out.secrets)
 
         assert certificate_secret.contents[1] == {
-            "certificate": new_certificate.strip(),
-            "csr": csr.strip(),
+            "certificate": new_certificate,
+            "csr": csr,
         }
 
     @patch(LIB_DIR + ".CertificateRequest.generate_csr")
@@ -759,7 +759,7 @@ class TestTLSCertificatesRequiresV4:
             private_key=private_key,
             common_name="example.com",
         )
-        csr_in_sha256_hex = get_sha256_hex(csr.strip())
+        csr_in_sha256_hex = get_sha256_hex(csr)
         provider_private_key = generate_private_key()
         provider_ca_certificate = generate_ca(
             private_key=provider_private_key,
@@ -809,7 +809,7 @@ class TestTLSCertificatesRequiresV4:
                 "certificate_signing_requests": json.dumps(
                     [
                         {
-                            "certificate_signing_request": csr.strip(),
+                            "certificate_signing_request": csr,
                             "ca": False,
                         }
                     ]
@@ -819,9 +819,9 @@ class TestTLSCertificatesRequiresV4:
                 "certificates": json.dumps(
                     [
                         {
-                            "certificate": certificate.strip(),
-                            "certificate_signing_request": csr.strip(),
-                            "ca": provider_ca_certificate.strip(),
+                            "certificate": certificate,
+                            "certificate_signing_request": csr,
+                            "ca": provider_ca_certificate,
                         }
                     ]
                 ),
@@ -849,7 +849,7 @@ class TestTLSCertificatesRequiresV4:
                     "certificate_signing_requests": json.dumps(
                         [
                             {
-                                "certificate_signing_request": new_csr.strip(),
+                                "certificate_signing_request": new_csr,
                                 "ca": False,
                             }
                         ]
@@ -859,9 +859,9 @@ class TestTLSCertificatesRequiresV4:
                     "certificates": json.dumps(
                         [
                             {
-                                "certificate": certificate.strip(),
-                                "certificate_signing_request": csr.strip(),
-                                "ca": provider_ca_certificate.strip(),
+                                "certificate": certificate,
+                                "certificate_signing_request": csr,
+                                "ca": provider_ca_certificate,
                             }
                         ]
                     ),

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
@@ -202,9 +202,7 @@ class TestTLSCertificatesRequiresV4:
 
         assert len(self.ctx.emitted_events) == 2
         assert isinstance(self.ctx.emitted_events[1], CertificateAvailableEvent)
-        assert self.ctx.emitted_events[1].certificate == Certificate.from_string(
-            certificate
-        )
+        assert self.ctx.emitted_events[1].certificate == Certificate.from_string(certificate)
         assert self.ctx.emitted_events[1].ca == Certificate.from_string(provider_ca_certificate)
         assert self.ctx.emitted_events[
             1


### PR DESCRIPTION
# Description

Implement the provider side of the TLS certificates library V4.

## Notable changes from V3

### Remove custom events

In our TLS Providers we heavily rely on getters (instead of the TLS custom events) to get the outstanding certificate requests and other tls related information. Because of this, we completely remove custom events from the tls lib v4. 

### Replace jsonschemas with Pydantic

Just like we did for the requirer side, we use Pydantic for relation data validation instead of json schemas. 

### Replace harness with scenario

Just like we did for the requirer side, here we use scenario instead of harness for unit testing.

### Remove Self Signed Certificates specific helpers
There were a couple of helper methods here that were used only by self signed certificates and those have been removed and will be added in the self-signed-certificates charm instead:
- generate_certificate
- generate_ca

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
