### PR TITLE
fix: do not load/dump when non leader in app mode

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -184,7 +184,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 1
 
 PYDEPS = ["cryptography", "pydantic"]
 
@@ -450,6 +450,8 @@ class CertificateSigningRequest:
 
     def __eq__(self, other: object) -> bool:
         """Check if two CertificateSigningRequest objects are equal."""
+        if not isinstance(other, CertificateSigningRequest):
+            return NotImplemented
         return self.raw.strip() == other.raw.strip()
 
     def __str__(self) -> str:
@@ -991,6 +993,9 @@ class TLSCertificatesRequiresV4(Object):
 
     def get_csrs_from_requirer_relation_data(self) -> List[CertificateSigningRequest]:
         """Return list of requirer's CSRs from relation data."""
+        if self.mode == Mode.APP and not self.model.unit.is_leader():
+            logger.debug("Not a leader unit - Skipping")
+            return []
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
             logger.debug("No relation: %s", self.relationship_name)
@@ -1011,6 +1016,9 @@ class TLSCertificatesRequiresV4(Object):
         return self._load_provider_certificates()
 
     def _load_provider_certificates(self) -> List[ProviderCertificate]:
+        if self.mode == Mode.APP and not self.model.unit.is_leader():
+            logger.debug("Not a leader unit - Skipping")
+            return []
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
             logger.debug("No relation: %s", self.relationship_name)
@@ -1030,6 +1038,9 @@ class TLSCertificatesRequiresV4(Object):
 
     def _request_certificate(self, csr: CertificateSigningRequest, is_ca: bool) -> None:
         """Add CSR to relation data."""
+        if self.mode == Mode.APP and not self.model.unit.is_leader():
+            logger.debug("Not a leader unit - Skipping")
+            return
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
             logger.debug("No relation: %s", self.relationship_name)

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -184,7 +184,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["cryptography", "pydantic"]
 
@@ -450,8 +450,6 @@ class CertificateSigningRequest:
 
     def __eq__(self, other: object) -> bool:
         """Check if two CertificateSigningRequest objects are equal."""
-        if not isinstance(other, CertificateSigningRequest):
-            return NotImplemented
         return self.raw.strip() == other.raw.strip()
 
     def __str__(self) -> str:

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -184,7 +184,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["cryptography", "pydantic"]
 

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -1016,9 +1016,6 @@ class TLSCertificatesRequiresV4(Object):
         return self._load_provider_certificates()
 
     def _load_provider_certificates(self) -> List[ProviderCertificate]:
-        if self.mode == Mode.APP and not self.model.unit.is_leader():
-            logger.debug("Not a leader unit - Skipping")
-            return []
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
             logger.debug("No relation: %s", self.relationship_name)


### PR DESCRIPTION
# Description

We prevent from reading/dumping to relation data when using the app mode.

## Logs
```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/model.py", line 3187, in _run
    result = subprocess.run(args, **kwargs)  # type: ignore
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '('/var/lib/juju/tools/unit-requirer-appl-1/relation-get', '-r', '2', '-', 'requirer-appl', '--app', '--format=json')' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/./src/charm.py", line 408, in <module>
    main(TLSRequirerCharm)
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/main.py", line 551, in main
    manager.run()
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/main.py", line 530, in run
    self._emit()
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/main.py", line 519, in _emit
    _emit_charm_event(self.charm, self.dispatcher.event_name)
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/main.py", line 147, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/framework.py", line 348, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/framework.py", line 860, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/framework.py", line 950, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/lib/charms/tls_certificates_interface/v4/tls_certificates.py", line 865, in _configure
    self._send_certificate_requests()
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/lib/charms/tls_certificates_interface/v4/tls_certificates.py", line 1067, in _send_certificate_requests
    if not self._certificate_requested(certificate_request):
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/lib/charms/tls_certificates_interface/v4/tls_certificates.py", line 979, in _certificate_requested
    csr = self._certificate_requested_for_attributes(certificate_request)
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/lib/charms/tls_certificates_interface/v4/tls_certificates.py", line 989, in _certificate_requested_for_attributes
    for requirer_csr in self.get_csrs_from_requirer_relation_data():
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/lib/charms/tls_certificates_interface/v4/tls_certificates.py", line 1005, in get_csrs_from_requirer_relation_data
    requirer_relation_data = _RequirerData.load(relation.data[app_or_unit])
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/lib/charms/tls_certificates_interface/v4/tls_certificates.py", line 224, in load
    data = {
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/lib/charms/tls_certificates_interface/v4/tls_certificates.py", line 224, in <dictcomp>
    data = {
  File "/usr/lib/python3.10/_collections_abc.py", line 910, in __iter__
    for key in self._mapping:
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/model.py", line 838, in __iter__
    return iter(self._data)
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/model.py", line 825, in _data
    data = self._lazy_data = self._load()
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/model.py", line 1700, in _load
    return self._backend.relation_get(self.relation.id, self._entity.name, self._is_app)
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/model.py", line 3264, in relation_get
    raw_data_content = self._run(*args, return_output=True, use_json=True)
  File "/var/lib/juju/agents/unit-requirer-appl-1/charm/venv/ops/model.py", line 3189, in _run
    raise ModelError(e.stderr) from e
ops.model.ModelError: ERROR permission denied
```
## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
