### PR TITLE
fix: use frozenset to represent sans

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -412,9 +412,8 @@ class Certificate:
             sans_dns = None
             sans_ip = None
             sans_oid = None
-
-        expiry_time = certificate_object.not_valid_after
-        validity_start_time = certificate_object.not_valid_before
+        expiry_time = certificate_object.not_valid_after_utc
+        validity_start_time = certificate_object.not_valid_before_utc
 
         return cls(
             raw=certificate.strip(),

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -158,7 +158,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import List, MutableMapping, Optional, Tuple, Union
+from typing import FrozenSet, List, MutableMapping, Optional, Tuple, Union
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -184,7 +184,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 PYDEPS = ["cryptography", "pydantic"]
 
@@ -352,9 +352,9 @@ class Certificate:
 
     raw: str
     common_name: str
-    sans_dns: Optional[Tuple[str, ...]] = None
-    sans_ip: Optional[Tuple[str, ...]] = None
-    sans_oid: Optional[Tuple[str, ...]] = None
+    sans_dns: Optional[FrozenSet[str]] = None
+    sans_ip: Optional[FrozenSet[str]] = None
+    sans_oid: Optional[FrozenSet[str]] = None
     email_address: Optional[str] = None
     organization: Optional[str] = None
     organizational_unit: Optional[str] = None
@@ -376,6 +376,7 @@ class Certificate:
         except ValueError as e:
             logger.error("Could not load certificate: %s", e)
             raise TLSCertificatesError("Could not load certificate")
+
         common_name = certificate_object.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
         country_name = certificate_object.subject.get_attributes_for_oid(NameOID.COUNTRY_NAME)
         state_or_province_name = certificate_object.subject.get_attributes_for_oid(
@@ -386,21 +387,22 @@ class Certificate:
             NameOID.ORGANIZATION_NAME
         )
         email_address = certificate_object.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
+
         try:
             sans = certificate_object.extensions.get_extension_for_class(
                 x509.SubjectAlternativeName
             ).value
-            sans_dns = tuple(
+            sans_dns = frozenset(
                 str(san)
                 for san in sans.get_values_for_type(x509.DNSName)
                 if isinstance(san, x509.DNSName)
             )
-            sans_ip = tuple(
+            sans_ip = frozenset(
                 str(san)
                 for san in sans.get_values_for_type(x509.IPAddress)
                 if isinstance(san, x509.IPAddress)
             )
-            sans_oid = tuple(
+            sans_oid = frozenset(
                 str(san)
                 for san in sans.get_values_for_type(x509.RegisteredID)
                 if isinstance(san, x509.RegisteredID)
@@ -410,8 +412,9 @@ class Certificate:
             sans_dns = None
             sans_ip = None
             sans_oid = None
-        expiry_time = certificate_object.not_valid_after_utc
-        validity_start_time = certificate_object.not_valid_before_utc
+
+        expiry_time = certificate_object.not_valid_after
+        validity_start_time = certificate_object.not_valid_before
 
         return cls(
             raw=certificate.strip(),
@@ -437,9 +440,9 @@ class CertificateSigningRequest:
 
     raw: str
     common_name: str
-    sans_dns: Optional[Tuple[str, ...]] = None
-    sans_ip: Optional[Tuple[str, ...]] = None
-    sans_oid: Optional[Tuple[str, ...]] = None
+    sans_dns: Optional[FrozenSet[str]] = None
+    sans_ip: Optional[FrozenSet[str]] = None
+    sans_oid: Optional[FrozenSet[str]] = None
     email_address: Optional[str] = None
     organization: Optional[str] = None
     organizational_unit: Optional[str] = None
@@ -492,14 +495,14 @@ class CertificateSigningRequest:
         email_address = csr_object.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
         try:
             sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
-            sans_dns = tuple(sans.get_values_for_type(x509.DNSName))
-            sans_ip = tuple([str(san) for san in sans.get_values_for_type(x509.IPAddress)])
-            sans_oid = tuple([str(san) for san in sans.get_values_for_type(x509.RegisteredID)])
+            sans_dns = frozenset(sans.get_values_for_type(x509.DNSName))
+            sans_ip = frozenset([str(san) for san in sans.get_values_for_type(x509.IPAddress)])
+            sans_oid = frozenset([str(san) for san in sans.get_values_for_type(x509.RegisteredID)])
         except x509.ExtensionNotFound:
-            sans = ()
-            sans_dns = ()
-            sans_ip = ()
-            sans_oid = ()
+            sans = frozenset()
+            sans_dns = frozenset()
+            sans_ip = frozenset()
+            sans_oid = frozenset()
         return cls(
             raw=csr.strip(),
             common_name=str(common_name[0].value),
@@ -577,9 +580,9 @@ class CertificateRequest:
     """
 
     common_name: str
-    sans_dns: Optional[Tuple[str, ...]] = None
-    sans_ip: Optional[Tuple[str, ...]] = None
-    sans_oid: Optional[Tuple[str, ...]] = None
+    sans_dns: Optional[FrozenSet[str]] = None
+    sans_ip: Optional[FrozenSet[str]] = None
+    sans_oid: Optional[FrozenSet[str]] = None
     email_address: Optional[str] = None
     organization: Optional[str] = None
     organizational_unit: Optional[str] = None

--- a/tests/integration/v4/requirer_charm/src/charm.py
+++ b/tests/integration/v4/requirer_charm/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from typing import Optional, Tuple, cast
+from typing import FrozenSet, Optional, cast
 
 from charms.tls_certificates_interface.v4.tls_certificates import (
     CertificateRequest,
@@ -78,9 +78,9 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
     def _get_config_common_name(self) -> str:
         return cast(str, self.model.config.get("common_name"))
 
-    def _get_config_sans_dns(self) -> Tuple[str, ...]:
+    def _get_config_sans_dns(self) -> FrozenSet[str]:
         config_sans_dns = cast(str, self.model.config.get("sans_dns", ""))
-        return tuple(config_sans_dns.split(",") if config_sans_dns else [])
+        return frozenset(config_sans_dns.split(",") if config_sans_dns else [])
 
     def _get_config_organization_name(self) -> Optional[str]:
         return cast(str, self.model.config.get("organization_name"))

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from typing import List, Optional, Tuple, cast
+from typing import FrozenSet, List, Optional, cast
 
 from ops.charm import ActionEvent, CharmBase
 from ops.main import main
@@ -76,9 +76,9 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
     def _get_config_common_name(self) -> str:
         return cast(str, self.model.config.get("common_name"))
 
-    def _get_config_sans_dns(self) -> Tuple[str, ...]:
+    def _get_config_sans_dns(self) -> FrozenSet[str]:
         config_sans_dns = cast(str, self.model.config.get("sans_dns", ""))
-        return tuple(config_sans_dns.split(",") if config_sans_dns else [])
+        return frozenset(config_sans_dns.split(",") if config_sans_dns else [])
 
     def _get_config_organization_name(self) -> Optional[str]:
         return cast(str, self.model.config.get("organization_name"))

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
@@ -197,7 +197,7 @@ class TestCertificateRequest:
 
         certificate_request = CertificateRequest(
             common_name="my.demo.server",
-            sans_dns=tuple("my.demo.server"),
+            sans_dns=frozenset(["my.demo.server"]),
             country_name="CA",
             state_or_province_name="Quebec",
             locality_name="Montreal",
@@ -223,8 +223,8 @@ class TestCertificateRequest:
 
         certificate_request = CertificateRequest(
             common_name="my.demo.server",
-            sans_dns=tuple("my.demo.server"),
-            sans_ip=("2001:db8::1", "2001:db8::2"),
+            sans_dns=frozenset(["my.demo.server"]),
+            sans_ip=frozenset(["2001:db8::1", "2001:db8::2"]),
         )
 
         csr = certificate_request.generate_csr(private_key=private_key)


### PR DESCRIPTION
# Description

There currently is an issue in v4 of the lib where two CertificateSigningRequest objects that have the same `sans_dns` but in different orders wouldn't be considered to be equal. Here we fix this issue by using frozensets instead of tuples for representing `sans`.


```python
a = CertificateRequest(common_name='tls-requirer-unit-2.test-integration-awm9', sans_dns=('example.org', 'example.com'), sans_ip=None, sans_oid=None, email_address=None, organization='Canonical', organizational_unit=None, country_name='GB', state_or_province_name='London', locality_name='London', is_ca=False)
b = CertificateRequest(common_name='tls-requirer-unit-2.test-integration-awm9', sans_dns=('example.com', 'example.org'), sans_ip=None, sans_oid=None, email_address=None, organization='Canonical', organizational_unit=None, country_name='GB', state_or_province_name='London', locality_name='London', is_ca=False)

assert a == b
```
```logs
Traceback (most recent call last):
  File "/home/guillaume/code/tls-certificates-requirer-operator/src/aaa.py", line 36, in <module>
    assert a == b
           ^^^^^^
AssertionError
```
## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
