### PR TITLE
fix: move get_provider_certificate to public

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -184,7 +184,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 PYDEPS = ["cryptography", "pydantic"]
 
@@ -1268,7 +1268,7 @@ class TLSCertificatesProvidesV4(Object):
         self._remove_certificates_for_which_no_csr_exists()
 
     def _remove_certificates_for_which_no_csr_exists(self) -> None:
-        provider_certificates = self._get_provider_certificates()
+        provider_certificates = self.get_provider_certificates()
         requirer_csrs = [
             request.certificate_signing_request for request in self.get_certificate_requests()
         ]
@@ -1429,10 +1429,10 @@ class TLSCertificatesProvidesV4(Object):
         if not self.model.unit.is_leader():
             logger.warning("Unit is not a leader - will not read relation data")
             return []
-        provider_certificates = self._get_provider_certificates(relation_id=relation_id)
+        provider_certificates = self.get_provider_certificates(relation_id=relation_id)
         return [certificate for certificate in provider_certificates if not certificate.revoked]
 
-    def _get_provider_certificates(
+    def get_provider_certificates(
         self, relation_id: Optional[int] = None
     ) -> List[ProviderCertificate]:
         """Return a List of issued certificates."""


### PR DESCRIPTION
# Description

`get_provider_certificate` is used inside of the LEGO K8s library and should be public.

## Reference:
- https://github.com/canonical/lego-base-k8s-operator/pull/162

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
