### PR TITLE
feat: add public certificate helpers

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -184,7 +184,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 PYDEPS = ["cryptography", "pydantic"]
 
@@ -386,35 +386,31 @@ class Certificate:
         organization_name = certificate_object.subject.get_attributes_for_oid(
             NameOID.ORGANIZATION_NAME
         )
+        organizational_unit = certificate_object.subject.get_attributes_for_oid(
+            NameOID.ORGANIZATIONAL_UNIT_NAME
+        )
         email_address = certificate_object.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
-
+        sans_dns: List[str] = []
+        sans_ip: List[str] = []
+        sans_oid: List[str] = []
         try:
             sans = certificate_object.extensions.get_extension_for_class(
                 x509.SubjectAlternativeName
             ).value
-            sans_dns = frozenset(
-                str(san)
-                for san in sans.get_values_for_type(x509.DNSName)
-                if isinstance(san, x509.DNSName)
-            )
-            sans_ip = frozenset(
-                str(san)
-                for san in sans.get_values_for_type(x509.IPAddress)
-                if isinstance(san, x509.IPAddress)
-            )
-            sans_oid = frozenset(
-                str(san)
-                for san in sans.get_values_for_type(x509.RegisteredID)
-                if isinstance(san, x509.RegisteredID)
-            )
+            for san in sans:
+                if isinstance(san, x509.DNSName):
+                    sans_dns.append(san.value)
+                if isinstance(san, x509.IPAddress):
+                    sans_ip.append(str(san.value))
+                if isinstance(san, x509.RegisteredID):
+                    sans_oid.append(str(san.value))
         except x509.ExtensionNotFound:
             logger.debug("No SANs found in certificate")
-            sans_dns = None
-            sans_ip = None
-            sans_oid = None
+            sans_dns = []
+            sans_ip = []
+            sans_oid = []
         expiry_time = certificate_object.not_valid_after_utc
         validity_start_time = certificate_object.not_valid_before_utc
-
         return cls(
             raw=certificate.strip(),
             common_name=str(common_name[0].value),
@@ -424,10 +420,11 @@ class Certificate:
             else None,
             locality_name=str(locality_name[0].value) if locality_name else None,
             organization=str(organization_name[0].value) if organization_name else None,
+            organizational_unit=str(organizational_unit[0].value) if organizational_unit else None,
             email_address=str(email_address[0].value) if email_address else None,
-            sans_dns=sans_dns,
-            sans_ip=sans_ip,
-            sans_oid=sans_oid,
+            sans_dns=frozenset(sans_dns),
+            sans_ip=frozenset(sans_ip),
+            sans_oid=frozenset(sans_oid),
             expiry_time=expiry_time,
             validity_start_time=validity_start_time,
         )
@@ -596,59 +593,31 @@ class CertificateRequest:
             return False
         return True
 
-    def generate_csr(  # noqa: C901
+    def generate_csr(
         self,
         private_key: PrivateKey,
-        add_unique_id_to_subject_name: bool = True,
     ) -> CertificateSigningRequest:
         """Generate a CSR using private key and subject.
 
         Args:
             private_key (PrivateKey): Private key
-            add_unique_id_to_subject_name (bool): Whether a unique ID must be added to the CSR's
-                subject name. Always leave to "True" when the CSR is used to request certificates
-                using the tls-certificates relation.
 
         Returns:
             CertificateSigningRequest: CSR
         """
-        signing_key = serialization.load_pem_private_key(str(private_key).encode(), password=None)
-        subject_name = [x509.NameAttribute(x509.NameOID.COMMON_NAME, self.common_name)]
-        if add_unique_id_to_subject_name:
-            unique_identifier = uuid.uuid4()
-            subject_name.append(
-                x509.NameAttribute(x509.NameOID.X500_UNIQUE_IDENTIFIER, str(unique_identifier))
-            )
-        if self.organization:
-            subject_name.append(
-                x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, self.organization)
-            )
-        if self.email_address:
-            subject_name.append(x509.NameAttribute(x509.NameOID.EMAIL_ADDRESS, self.email_address))
-        if self.country_name:
-            subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, self.country_name))
-        if self.state_or_province_name:
-            subject_name.append(
-                x509.NameAttribute(
-                    x509.NameOID.STATE_OR_PROVINCE_NAME, self.state_or_province_name
-                )
-            )
-        if self.locality_name:
-            subject_name.append(x509.NameAttribute(x509.NameOID.LOCALITY_NAME, self.locality_name))
-        csr = x509.CertificateSigningRequestBuilder(subject_name=x509.Name(subject_name))
-
-        _sans: List[x509.GeneralName] = []
-        if self.sans_oid:
-            _sans.extend([x509.RegisteredID(x509.ObjectIdentifier(san)) for san in self.sans_oid])
-        if self.sans_ip:
-            _sans.extend([x509.IPAddress(ipaddress.ip_address(san)) for san in self.sans_ip])
-        if self.sans_dns:
-            _sans.extend([x509.DNSName(san) for san in self.sans_dns])
-        if _sans:
-            csr = csr.add_extension(x509.SubjectAlternativeName(set(_sans)), critical=False)
-        signed_certificate = csr.sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
-        csr_str = signed_certificate.public_bytes(serialization.Encoding.PEM).decode()
-        return CertificateSigningRequest.from_string(csr_str)
+        return generate_csr(
+            private_key=private_key,
+            common_name=self.common_name,
+            sans_dns=self.sans_dns,
+            sans_ip=self.sans_ip,
+            sans_oid=self.sans_oid,
+            email_address=self.email_address,
+            organization=self.organization,
+            organizational_unit=self.organizational_unit,
+            country_name=self.country_name,
+            state_or_province_name=self.state_or_province_name,
+            locality_name=self.locality_name,
+        )
 
 
 @dataclass(frozen=True)
@@ -780,7 +749,7 @@ def calculate_expiry_notification_time(
     return expiry_time - timedelta(hours=calculated_hours)
 
 
-def _generate_private_key(
+def generate_private_key(
     key_size: int = 2048,
     public_exponent: int = 65537,
 ) -> PrivateKey:
@@ -803,6 +772,187 @@ def _generate_private_key(
         encryption_algorithm=serialization.NoEncryption(),
     )
     return PrivateKey.from_string(key_bytes.decode())
+
+
+def generate_csr(  # noqa: C901
+    private_key: PrivateKey,
+    common_name: str,
+    sans_dns: Optional[FrozenSet[str]] = None,
+    sans_ip: Optional[FrozenSet[str]] = None,
+    sans_oid: Optional[FrozenSet[str]] = None,
+    organization: Optional[str] = None,
+    organizational_unit: Optional[str] = None,
+    email_address: Optional[str] = None,
+    country_name: Optional[str] = None,
+    locality_name: Optional[str] = None,
+    state_or_province_name: Optional[str] = None,
+    add_unique_id_to_subject_name: bool = True,
+) -> CertificateSigningRequest:
+    """Generate a CSR using private key and subject.
+
+    Args:
+        private_key (PrivateKey): Private key
+        common_name (str): Common name
+        sans_dns (FrozenSet[str]): DNS Subject Alternative Names
+        sans_ip (FrozenSet[str]): IP Subject Alternative Names
+        sans_oid (FrozenSet[str]): OID Subject Alternative Names
+        organization (Optional[str]): Organization name
+        organizational_unit (Optional[str]): Organizational unit name
+        email_address (Optional[str]): Email address
+        country_name (Optional[str]): Country name
+        state_or_province_name (Optional[str]): State or province name
+        locality_name (Optional[str]): Locality name
+        add_unique_id_to_subject_name (bool): Whether a unique ID must be added to the CSR's
+            subject name. Always leave to "True" when the CSR is used to request certificates
+            using the tls-certificates relation.
+
+    Returns:
+        CertificateSigningRequest: CSR
+    """
+    signing_key = serialization.load_pem_private_key(str(private_key).encode(), password=None)
+    subject_name = [x509.NameAttribute(x509.NameOID.COMMON_NAME, common_name)]
+    if add_unique_id_to_subject_name:
+        unique_identifier = uuid.uuid4()
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.X500_UNIQUE_IDENTIFIER, str(unique_identifier))
+        )
+    if organization:
+        subject_name.append(x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, organization))
+    if organizational_unit:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.ORGANIZATIONAL_UNIT_NAME, organizational_unit)
+        )
+    if email_address:
+        subject_name.append(x509.NameAttribute(x509.NameOID.EMAIL_ADDRESS, email_address))
+    if country_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name))
+    if state_or_province_name:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, state_or_province_name)
+        )
+    if locality_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.LOCALITY_NAME, locality_name))
+    csr = x509.CertificateSigningRequestBuilder(subject_name=x509.Name(subject_name))
+
+    _sans: List[x509.GeneralName] = []
+    if sans_oid:
+        _sans.extend([x509.RegisteredID(x509.ObjectIdentifier(san)) for san in sans_oid])
+    if sans_ip:
+        _sans.extend([x509.IPAddress(ipaddress.ip_address(san)) for san in sans_ip])
+    if sans_dns:
+        _sans.extend([x509.DNSName(san) for san in sans_dns])
+    if _sans:
+        csr = csr.add_extension(x509.SubjectAlternativeName(set(_sans)), critical=False)
+    signed_certificate = csr.sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
+    csr_str = signed_certificate.public_bytes(serialization.Encoding.PEM).decode()
+    return CertificateSigningRequest.from_string(csr_str)
+
+
+def generate_ca(
+    private_key: PrivateKey,
+    validity: int,
+    common_name: str,
+    sans_dns: Optional[FrozenSet[str]] = None,
+    sans_ip: Optional[FrozenSet[str]] = None,
+    sans_oid: Optional[FrozenSet[str]] = None,
+    organization: Optional[str] = None,
+    organizational_unit: Optional[str] = None,
+    email_address: Optional[str] = None,
+    country_name: Optional[str] = None,
+    state_or_province_name: Optional[str] = None,
+    locality_name: Optional[str] = None,
+) -> Certificate:
+    """Generate a self signed CA Certificate.
+
+    Args:
+        private_key (PrivateKey): Private key
+        validity (int): Certificate validity time (in days)
+        common_name (str): Common Name that can be an IP or a Full Qualified Domain Name (FQDN).
+        sans_dns (FrozenSet[str]): DNS Subject Alternative Names
+        sans_ip (FrozenSet[str]): IP Subject Alternative Names
+        sans_oid (FrozenSet[str]): OID Subject Alternative Names
+        organization (Optional[str]): Organization name
+        organizational_unit (Optional[str]): Organizational unit name
+        email_address (Optional[str]): Email address
+        country_name (str): Certificate Issuing country
+        state_or_province_name (str): Certificate Issuing state or province
+        locality_name (str): Certificate Issuing locality
+
+    Returns:
+        Certificate: CA Certificate.
+    """
+    private_key_object = serialization.load_pem_private_key(
+        str(private_key).encode(), password=None
+    )
+    assert isinstance(private_key_object, rsa.RSAPrivateKey)
+    subject_name = [x509.NameAttribute(x509.NameOID.COMMON_NAME, common_name)]
+    if organization:
+        subject_name.append(x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, organization))
+    if organizational_unit:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.ORGANIZATIONAL_UNIT_NAME, organizational_unit)
+        )
+    if email_address:
+        subject_name.append(x509.NameAttribute(x509.NameOID.EMAIL_ADDRESS, email_address))
+    if country_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name))
+    if state_or_province_name:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, state_or_province_name)
+        )
+    if locality_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.LOCALITY_NAME, locality_name))
+
+    _sans: List[x509.GeneralName] = []
+    if sans_oid:
+        _sans.extend([x509.RegisteredID(x509.ObjectIdentifier(san)) for san in sans_oid])
+    if sans_ip:
+        _sans.extend([x509.IPAddress(ipaddress.ip_address(san)) for san in sans_ip])
+    if sans_dns:
+        _sans.extend([x509.DNSName(san) for san in sans_dns])
+
+    subject_identifier_object = x509.SubjectKeyIdentifier.from_public_key(
+        private_key_object.public_key()
+    )
+    subject_identifier = key_identifier = subject_identifier_object.public_bytes()
+    key_usage = x509.KeyUsage(
+        digital_signature=True,
+        key_encipherment=True,
+        key_cert_sign=True,
+        key_agreement=False,
+        content_commitment=False,
+        data_encipherment=False,
+        crl_sign=False,
+        encipher_only=False,
+        decipher_only=False,
+    )
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name(subject_name))
+        .issuer_name(x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, common_name)]))
+        .public_key(private_key_object.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
+        .add_extension(x509.SubjectAlternativeName(set(_sans)), critical=False)
+        .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier(
+                key_identifier=key_identifier,
+                authority_cert_issuer=None,
+                authority_cert_serial_number=None,
+            ),
+            critical=False,
+        )
+        .add_extension(key_usage, critical=True)
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
+        )
+        .sign(private_key_object, hashes.SHA256())  # type: ignore[arg-type]
+    )
+    ca_cert_str = cert.public_bytes(serialization.Encoding.PEM).decode().strip()
+    return Certificate.from_string(ca_cert_str)
 
 
 class CertificatesRequirerCharmEvents(CharmEvents):
@@ -939,7 +1089,7 @@ class TLSCertificatesRequiresV4(Object):
     def _generate_private_key(self) -> None:
         if self._private_key_generated():
             return
-        private_key = _generate_private_key()
+        private_key = generate_private_key()
         self.charm.unit.add_secret(
             content={"private-key": str(private_key)},
             label=self._get_private_key_secret_label(),
@@ -960,7 +1110,7 @@ class TLSCertificatesRequiresV4(Object):
 
     def _regenerate_private_key(self) -> None:
         secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
-        secret.set_content({"private-key": str(_generate_private_key())})
+        secret.set_content({"private-key": str(generate_private_key())})
 
     def _private_key_generated(self) -> bool:
         try:

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
@@ -7,9 +7,10 @@ from datetime import datetime, timedelta, timezone
 from ipaddress import IPv6Address
 
 from charms.tls_certificates_interface.v4.tls_certificates import (
-    CertificateRequest,
     PrivateKey,
-    _generate_private_key,
+    generate_ca,
+    generate_csr,
+    generate_private_key,
 )
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
@@ -35,11 +36,14 @@ def validate_induced_data_from_pfx_is_equal_to_initial_data(
         induced_certificate_object,
         _,
     ) = pkcs12.load_key_and_certificates(pfx_file, password.encode())
+    assert induced_private_key_object
+    assert induced_certificate_object
     initial_private_key_object = load_pem_private_key(
         initial_private_key,
         password=None,
     )
-    induced_private_key = induced_private_key_object.private_bytes(  # type: ignore[union-attr]
+    assert initial_private_key_object
+    induced_private_key = induced_private_key_object.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
@@ -49,12 +53,12 @@ def validate_induced_data_from_pfx_is_equal_to_initial_data(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.PKCS1,
     )
-    induced_public_key_object = induced_private_key_object.public_key()  # type: ignore[union-attr]
+    induced_public_key_object = induced_private_key_object.public_key()
     induced_public_key = induced_public_key_object.public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.PKCS1,
     )
-    induced_certificate = induced_certificate_object.public_bytes(  # type: ignore[union-attr]
+    induced_certificate = induced_certificate_object.public_bytes(
         encoding=serialization.Encoding.PEM
     )
 
@@ -64,7 +68,7 @@ def validate_induced_data_from_pfx_is_equal_to_initial_data(
 
 
 def test_given_no_password_when_generate_private_key_then_key_is_generated_and_loadable():
-    private_key = _generate_private_key()
+    private_key = generate_private_key()
 
     load_pem_private_key(data=str(private_key).encode(), password=None)
 
@@ -72,13 +76,16 @@ def test_given_no_password_when_generate_private_key_then_key_is_generated_and_l
 def test_given_key_size_provided_when_generate_private_key_then_private_key_is_generated():
     key_size = 1234
 
-    private_key = _generate_private_key(key_size=key_size)
+    private_key = generate_private_key(key_size=key_size)
 
     private_key_object = serialization.load_pem_private_key(
         str(private_key).encode(), password=None
     )
     assert isinstance(private_key_object, rsa.RSAPrivateKeyWithSerialization)
     assert private_key_object.key_size == key_size
+
+
+# calculate expiry notification time
 
 
 def test_given_provider_recommended_notification_time_when_calculate_expiry_notification_time_then_returns_provider_recommendation():  # noqa: E501
@@ -113,7 +120,7 @@ def test_given_negative_provider_recommended_notification_time_when_calculate_ex
     assert notification_time == expected_notification_time
 
 
-def test_given_requirer_and_provider_recommendations_are_invalid_whencalculate_expiry_notification_time_then_returns_calculated_notification_time():  # noqa: E501
+def test_given_requirer_and_provider_recommendations_are_invalid_when_calculate_expiry_notification_time_then_returns_calculated_notification_time():  # noqa: E501
     expiry_time = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     validity_start_time_in_hours = 240
     validity_start_time = expiry_time - timedelta(hours=validity_start_time_in_hours)
@@ -128,7 +135,7 @@ def test_given_requirer_and_provider_recommendations_are_invalid_whencalculate_e
     assert notification_time == expected_notification_time
 
 
-def test_given_negative_requirer_and_provider_recommendations_are_invalid_whencalculate_expiry_notification_time_then_returns_calculated_notification_time():  # noqa: E501
+def test_given_negative_requirer_and_provider_recommendations_are_invalid_when_calculate_expiry_notification_time_then_returns_calculated_notification_time():  # noqa: E501
     expiry_time = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     validity_start_time_in_hours = 240
     validity_start_time = expiry_time - timedelta(hours=validity_start_time_in_hours)
@@ -158,80 +165,109 @@ def test_given_validity_time_is_too_short_when_calculate_expiry_notification_tim
     assert notification_time == expected_notification_time
 
 
-class TestCertificateRequest:
-    def test_given_subject_and_private_key_when_generate_csr_then_csr_is_generated_with_provided_subject(  # noqa: E501
-        self,
-    ):
-        subject = "whatever"
-        private_key = PrivateKey(raw=generate_private_key_helper())
+# Generate CSR
 
-        certificate_request = CertificateRequest(common_name=subject)
 
-        csr = certificate_request.generate_csr(private_key=private_key)
+def test_given_subject_and_private_key_when_generate_csr_then_csr_is_generated_with_provided_subject():  # noqa: E501
+    common_name = "whatever"
+    private_key = PrivateKey(raw=generate_private_key_helper())
 
-        csr_object = x509.load_pem_x509_csr(data=str(csr).encode())
-        subject_list = list(csr_object.subject)
-        assert len(subject_list) == 2
-        assert subject == subject_list[0].value
-        uuid.UUID(str(subject_list[1].value))
+    csr = generate_csr(private_key=private_key, common_name=common_name)
 
-    def test_given_unique_id_set_to_false_when_generate_csr_then_csr_is_generated_without_unique_id(  # noqa: E501
-        self,
-    ):
-        private_key = PrivateKey(raw=generate_private_key_helper())
-        subject = "whatever subject"
-        certificate_request = CertificateRequest(common_name=subject)
+    csr_object = x509.load_pem_x509_csr(data=str(csr).encode())
+    subject_list = list(csr_object.subject)
+    assert len(subject_list) == 2
+    assert common_name == subject_list[0].value
+    uuid.UUID(str(subject_list[1].value))
 
-        csr = certificate_request.generate_csr(
-            private_key=private_key, add_unique_id_to_subject_name=False
-        )
 
-        csr_object = x509.load_pem_x509_csr(data=str(csr).encode())
-        subject_list = list(csr_object.subject)
-        assert subject == subject_list[0].value
+def test_given_unique_id_set_to_false_when_generate_csr_then_csr_is_generated_without_unique_id(  # noqa: E501
+):
+    private_key = PrivateKey(raw=generate_private_key_helper())
+    common_name = "whatever subject"
 
-    def test_given_localization_is_specified_when__generate_csr_then_csr_contains_localization(
-        self,
-    ):
-        private_key = _generate_private_key()
+    csr = generate_csr(
+        private_key=private_key, common_name=common_name, add_unique_id_to_subject_name=False
+    )
 
-        certificate_request = CertificateRequest(
-            common_name="my.demo.server",
-            sans_dns=frozenset(["my.demo.server"]),
-            country_name="CA",
-            state_or_province_name="Quebec",
-            locality_name="Montreal",
-        )
+    csr_object = x509.load_pem_x509_csr(data=str(csr).encode())
+    subject_list = list(csr_object.subject)
+    assert common_name == subject_list[0].value
 
-        csr = certificate_request.generate_csr(private_key=private_key)
 
-        csr_object = x509.load_pem_x509_csr(str(csr).encode())
-        assert (
-            csr_object.subject.get_attributes_for_oid(x509.NameOID.COUNTRY_NAME)[0].value == "CA"
-        )
-        assert (
-            csr_object.subject.get_attributes_for_oid(x509.NameOID.STATE_OR_PROVINCE_NAME)[0].value
-            == "Quebec"
-        )
-        assert (
-            csr_object.subject.get_attributes_for_oid(x509.NameOID.LOCALITY_NAME)[0].value
-            == "Montreal"
-        )
+def test_given_localization_is_specified_when_generate_csr_then_csr_contains_localization():
+    private_key = generate_private_key()
 
-    def test_given_ipv6_sans_when__generate_csr_then_csr_contains_ipv6_sans(self):
-        private_key = _generate_private_key()
+    csr = generate_csr(
+        private_key=private_key,
+        common_name="my.demo.server",
+        sans_dns=frozenset(["my.demo.server"]),
+        country_name="CA",
+        state_or_province_name="Quebec",
+        locality_name="Montreal",
+    )
 
-        certificate_request = CertificateRequest(
-            common_name="my.demo.server",
-            sans_dns=frozenset(["my.demo.server"]),
-            sans_ip=frozenset(["2001:db8::1", "2001:db8::2"]),
-        )
+    csr_object = x509.load_pem_x509_csr(str(csr).encode())
+    assert csr_object.subject.get_attributes_for_oid(x509.NameOID.COUNTRY_NAME)[0].value == "CA"
+    assert (
+        csr_object.subject.get_attributes_for_oid(x509.NameOID.STATE_OR_PROVINCE_NAME)[0].value
+        == "Quebec"
+    )
+    assert (
+        csr_object.subject.get_attributes_for_oid(x509.NameOID.LOCALITY_NAME)[0].value
+        == "Montreal"
+    )
 
-        csr = certificate_request.generate_csr(private_key=private_key)
 
-        csr_object = x509.load_pem_x509_csr(str(csr).encode())
-        sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
-        sans_ip = sans.get_values_for_type(x509.IPAddress)
-        assert len(sans_ip) == 2
-        assert IPv6Address("2001:db8::1") in sans_ip
-        assert IPv6Address("2001:db8::2") in sans_ip
+def test_given_ipv6_sans_when_generate_csr_then_csr_contains_ipv6_sans():
+    private_key = generate_private_key()
+
+    csr = generate_csr(
+        private_key=private_key,
+        common_name="my.demo.server",
+        sans_dns=frozenset(["my.demo.server"]),
+        sans_ip=frozenset(["2001:db8::1", "2001:db8::2"]),
+    )
+
+    csr_object = x509.load_pem_x509_csr(str(csr).encode())
+    sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+    sans_ip = sans.get_values_for_type(x509.IPAddress)
+    assert len(sans_ip) == 2
+    assert IPv6Address("2001:db8::1") in sans_ip
+    assert IPv6Address("2001:db8::2") in sans_ip
+
+
+# Generate CA
+
+
+def test_given_ca_certificate_attributes_when_generate_ca_then_ca_is_generated_correctly():
+    common_name = "certifier.example.com"
+    private_key = PrivateKey(raw=generate_private_key_helper())
+
+    ca_certificate = generate_ca(
+        private_key=private_key,
+        validity=365,
+        common_name=common_name,
+        sans_dns=frozenset(["certifier.example.com"]),
+        sans_ip=frozenset(["1.2.3.4"]),
+        email_address="banana@gmail.com",
+        organization="Example",
+        organizational_unit="Example Unit",
+        country_name="CA",
+        state_or_province_name="Quebec",
+        locality_name="Montreal",
+    )
+
+    assert ca_certificate.common_name == common_name
+    expected_expiry = datetime.now(timezone.utc) + timedelta(days=365)
+    assert ca_certificate.expiry_time
+    assert abs(ca_certificate.expiry_time - expected_expiry) <= timedelta(seconds=1)
+    assert ca_certificate.email_address == "banana@gmail.com"
+    assert ca_certificate.organization == "Example"
+    assert ca_certificate.organizational_unit == "Example Unit"
+    assert ca_certificate.country_name == "CA"
+    assert ca_certificate.state_or_province_name == "Quebec"
+    assert ca_certificate.locality_name == "Montreal"
+    assert ca_certificate.sans_dns == frozenset(["certifier.example.com"])
+    assert ca_certificate.sans_ip == frozenset(["1.2.3.4"])
+    assert ca_certificate.sans_oid == frozenset()


### PR DESCRIPTION
# Description

Here we add the same certificate helpers we had in previous versions of the lib:
- generate_private_key
- generate_csr
- generate_ca
- generate_certificate


## Rationale
The use of those helpers can be separated in 3 categories:
- In charm code of TLS requirers (when the charm is not integrated with a TLS provider and we want to generate self signed certs instead).
- In unit tests of TLS requirers
- In the self-signed certificates charm

If we do not include those here in the lib, many charms will create their own implementation. The rationale here is to centralise those helper methods in 1 place.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
