### PR TITLE
fix: small doc error

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -761,7 +761,7 @@ def generate_private_key(
         public_exponent: Public exponent.
 
     Returns:
-        str: Private Key
+        PrivateKey: Private Key
     """
     private_key = rsa.generate_private_key(
         public_exponent=public_exponent,


### PR DESCRIPTION
# Description

This change fixes a small mistake in the docs of the return type of the generate_private_key function.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
