### PR TITLE
fix: allow ca certificate requests

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -353,7 +353,7 @@ class Certificate:
 
     raw: str
     common_name: str
-    is_ca: bool
+    is_ca: bool = False
     sans_dns: Optional[FrozenSet[str]] = frozenset()
     sans_ip: Optional[FrozenSet[str]] = frozenset()
     sans_oid: Optional[FrozenSet[str]] = frozenset()
@@ -413,13 +413,13 @@ class Certificate:
             sans_oid = []
         expiry_time = certificate_object.not_valid_after_utc
         validity_start_time = certificate_object.not_valid_before_utc
-        is_ca: bool = False
+        is_ca = False
         try:
             is_ca = certificate_object.extensions.get_extension_for_oid(
                 ExtensionOID.BASIC_CONSTRAINTS
             ).value.ca  # type: ignore[reportAttributeAccessIssue]
         except x509.ExtensionNotFound:
-            is_ca = False
+            pass
 
         return cls(
             raw=certificate.strip(),

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -185,7 +185,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 PYDEPS = ["cryptography", "pydantic"]
 
@@ -353,9 +353,10 @@ class Certificate:
 
     raw: str
     common_name: str
-    sans_dns: Optional[FrozenSet[str]] = None
-    sans_ip: Optional[FrozenSet[str]] = None
-    sans_oid: Optional[FrozenSet[str]] = None
+    is_ca: bool
+    sans_dns: Optional[FrozenSet[str]] = frozenset()
+    sans_ip: Optional[FrozenSet[str]] = frozenset()
+    sans_oid: Optional[FrozenSet[str]] = frozenset()
     email_address: Optional[str] = None
     organization: Optional[str] = None
     organizational_unit: Optional[str] = None
@@ -412,9 +413,18 @@ class Certificate:
             sans_oid = []
         expiry_time = certificate_object.not_valid_after_utc
         validity_start_time = certificate_object.not_valid_before_utc
+        is_ca: bool = False
+        try:
+            is_ca = certificate_object.extensions.get_extension_for_oid(
+                ExtensionOID.BASIC_CONSTRAINTS
+            ).value.ca
+        except x509.ExtensionNotFound:
+            is_ca = False
+
         return cls(
             raw=certificate.strip(),
             common_name=str(common_name[0].value),
+            is_ca=is_ca,
             country_name=str(country_name[0].value) if country_name else None,
             state_or_province_name=str(state_or_province_name[0].value)
             if state_or_province_name
@@ -446,7 +456,6 @@ class CertificateSigningRequest:
     country_name: Optional[str] = None
     state_or_province_name: Optional[str] = None
     locality_name: Optional[str] = None
-    is_ca: bool = False
 
     def __eq__(self, other: object) -> bool:
         """Check if two CertificateSigningRequest objects are equal."""
@@ -457,22 +466,6 @@ class CertificateSigningRequest:
     def __str__(self) -> str:
         """Return the CSR as a string."""
         return self.raw
-
-    def to_certificate_request(self) -> "CertificateRequest":
-        """Convert to a CertificateRequest object."""
-        return CertificateRequest(
-            common_name=self.common_name,
-            sans_dns=self.sans_dns,
-            sans_ip=self.sans_ip,
-            sans_oid=self.sans_oid,
-            email_address=self.email_address,
-            organization=self.organization,
-            organizational_unit=self.organizational_unit,
-            country_name=self.country_name,
-            state_or_province_name=self.state_or_province_name,
-            locality_name=self.locality_name,
-            is_ca=self.is_ca,
-        )
 
     @classmethod
     def from_string(cls, csr: str) -> "CertificateSigningRequest":
@@ -511,8 +504,8 @@ class CertificateSigningRequest:
             organization=str(organization_name[0].value) if organization_name else None,
             email_address=str(email_address[0].value) if email_address else None,
             sans_dns=sans_dns,
-            sans_ip=sans_ip if sans_ip else None,
-            sans_oid=sans_oid if sans_oid else None,
+            sans_ip=sans_ip,
+            sans_oid=sans_oid,
         )
 
     def matches_private_key(self, key: PrivateKey) -> bool:
@@ -577,9 +570,9 @@ class CertificateRequest:
     """
 
     common_name: str
-    sans_dns: Optional[FrozenSet[str]] = None
-    sans_ip: Optional[FrozenSet[str]] = None
-    sans_oid: Optional[FrozenSet[str]] = None
+    sans_dns: Optional[FrozenSet[str]] = frozenset()
+    sans_ip: Optional[FrozenSet[str]] = frozenset()
+    sans_oid: Optional[FrozenSet[str]] = frozenset()
     email_address: Optional[str] = None
     organization: Optional[str] = None
     organizational_unit: Optional[str] = None
@@ -620,6 +613,23 @@ class CertificateRequest:
             locality_name=self.locality_name,
         )
 
+    @classmethod
+    def from_csr(cls, csr: CertificateSigningRequest, is_ca: bool):
+        """Create a CertificateRequest object from a CSR."""
+        return cls(
+            common_name=csr.common_name,
+            sans_dns=csr.sans_dns,
+            sans_ip=csr.sans_ip,
+            sans_oid=csr.sans_oid,
+            email_address=csr.email_address,
+            organization=csr.organization,
+            organizational_unit=csr.organizational_unit,
+            country_name=csr.country_name,
+            state_or_province_name=csr.state_or_province_name,
+            locality_name=csr.locality_name,
+            is_ca=is_ca,
+        )
+
 
 @dataclass(frozen=True)
 class ProviderCertificate:
@@ -656,6 +666,7 @@ class RequirerCSR:
 
     relation_id: int
     certificate_signing_request: CertificateSigningRequest
+    is_ca: bool
 
 
 class CertificateAvailableEvent(EventBase):
@@ -778,9 +789,9 @@ def generate_private_key(
 def generate_csr(  # noqa: C901
     private_key: PrivateKey,
     common_name: str,
-    sans_dns: Optional[FrozenSet[str]] = None,
-    sans_ip: Optional[FrozenSet[str]] = None,
-    sans_oid: Optional[FrozenSet[str]] = None,
+    sans_dns: Optional[FrozenSet[str]] = frozenset(),
+    sans_ip: Optional[FrozenSet[str]] = frozenset(),
+    sans_oid: Optional[FrozenSet[str]] = frozenset(),
     organization: Optional[str] = None,
     organizational_unit: Optional[str] = None,
     email_address: Optional[str] = None,
@@ -853,9 +864,9 @@ def generate_ca(
     private_key: PrivateKey,
     validity: int,
     common_name: str,
-    sans_dns: Optional[FrozenSet[str]] = None,
-    sans_ip: Optional[FrozenSet[str]] = None,
-    sans_oid: Optional[FrozenSet[str]] = None,
+    sans_dns: Optional[FrozenSet[str]] = frozenset(),
+    sans_ip: Optional[FrozenSet[str]] = frozenset(),
+    sans_oid: Optional[FrozenSet[str]] = frozenset(),
     organization: Optional[str] = None,
     organizational_unit: Optional[str] = None,
     email_address: Optional[str] = None,
@@ -1269,10 +1280,25 @@ class TLSCertificatesRequiresV4(Object):
             return False
         return True
 
-    def _csr_matches_certificate_request(self, csr: CertificateSigningRequest) -> bool:
+    def _csr_matches_certificate_request(
+        self, certificate_signing_request: CertificateSigningRequest, is_ca: bool
+    ) -> bool:
         for certificate_request in self.certificate_requests:
-            if csr.to_certificate_request() == certificate_request:
+            logger.warning(
+                "TO DELETE: Relation Data Request: %s",
+                CertificateRequest.from_csr(
+                    certificate_signing_request,
+                    is_ca,
+                ),
+            )
+            logger.warning("TO DELETE: Certificate Request: %s", certificate_request)
+            if certificate_request == CertificateRequest.from_csr(
+                certificate_signing_request,
+                is_ca,
+            ):
+                logger.warning("TO DELETE: Match found")
                 return True
+        logger.warning("TO DELETE: No match found")
         return False
 
     def _certificate_requested(self, certificate_request: CertificateRequest) -> bool:
@@ -1281,19 +1307,23 @@ class TLSCertificatesRequiresV4(Object):
         csr = self._certificate_requested_for_attributes(certificate_request)
         if not csr:
             return False
-        if not csr.matches_private_key(key=self.private_key):
+        if not csr.certificate_signing_request.matches_private_key(key=self.private_key):
             return False
         return True
 
     def _certificate_requested_for_attributes(
-        self, certificate_request: CertificateRequest
-    ) -> Optional[CertificateSigningRequest]:
+        self,
+        certificate_request: CertificateRequest,
+    ) -> Optional[RequirerCSR]:
         for requirer_csr in self.get_csrs_from_requirer_relation_data():
-            if requirer_csr.to_certificate_request() == certificate_request:
+            if certificate_request == CertificateRequest.from_csr(
+                requirer_csr.certificate_signing_request,
+                requirer_csr.is_ca,
+            ):
                 return requirer_csr
         return None
 
-    def get_csrs_from_requirer_relation_data(self) -> List[CertificateSigningRequest]:
+    def get_csrs_from_requirer_relation_data(self) -> List[RequirerCSR]:
         """Return list of requirer's CSRs from relation data."""
         if self.mode == Mode.APP and not self.model.unit.is_leader():
             logger.debug("Not a leader unit - Skipping")
@@ -1308,10 +1338,18 @@ class TLSCertificatesRequiresV4(Object):
         except DataValidationError:
             logger.warning("Invalid relation data")
             return []
-        return [
-            CertificateSigningRequest.from_string(csr.certificate_signing_request)
-            for csr in requirer_relation_data.certificate_signing_requests
-        ]
+        requirer_csrs = []
+        for csr in requirer_relation_data.certificate_signing_requests:
+            requirer_csrs.append(
+                RequirerCSR(
+                    relation_id=relation.id,
+                    certificate_signing_request=CertificateSigningRequest.from_string(
+                        csr.certificate_signing_request
+                    ),
+                    is_ca=csr.ca if csr.ca else False,
+                )
+            )
+        return requirer_csrs
 
     def get_provider_certificates(self) -> List[ProviderCertificate]:
         """Return list of certificates from the provider's relation data."""
@@ -1383,7 +1421,10 @@ class TLSCertificatesRequiresV4(Object):
     ) -> Tuple[ProviderCertificate | None, PrivateKey | None]:
         """Get the certificate that was assigned to the given certificate request."""
         for requirer_csr in self.get_csrs_from_requirer_relation_data():
-            if certificate_request == requirer_csr.to_certificate_request():
+            if certificate_request == CertificateRequest.from_csr(
+                requirer_csr.certificate_signing_request,
+                requirer_csr.is_ca,
+            ):
                 return self._find_certificate_in_relation_data(requirer_csr), self.private_key
         return None, None
 
@@ -1396,11 +1437,14 @@ class TLSCertificatesRequiresV4(Object):
         return assigned_certificates, self.private_key
 
     def _find_certificate_in_relation_data(
-        self, csr: CertificateSigningRequest
+        self, csr: RequirerCSR
     ) -> Optional[ProviderCertificate]:
         """Return the certificate that match the given CSR."""
         for provider_certificate in self.get_provider_certificates():
-            if provider_certificate.certificate_signing_request == csr:
+            if (
+                provider_certificate.certificate_signing_request == csr.certificate_signing_request
+                and provider_certificate.certificate.is_ca == csr.is_ca
+            ):
                 return provider_certificate
         return None
 
@@ -1412,9 +1456,10 @@ class TLSCertificatesRequiresV4(Object):
         If a certificate is revoked, the secret will be removed and an event will be emitted.
         """
         requirer_csrs = self.get_csrs_from_requirer_relation_data()
+        csrs = [csr.certificate_signing_request for csr in requirer_csrs]
         provider_certificates = self.get_provider_certificates()
         for provider_certificate in provider_certificates:
-            if provider_certificate.certificate_signing_request in requirer_csrs:
+            if provider_certificate.certificate_signing_request in csrs:
                 secret_label = self._get_csr_secret_label(
                     provider_certificate.certificate_signing_request
                 )
@@ -1428,7 +1473,8 @@ class TLSCertificatesRequiresV4(Object):
                         secret.remove_all_revisions()
                 else:
                     if not self._csr_matches_certificate_request(
-                        provider_certificate.certificate_signing_request
+                        certificate_signing_request=provider_certificate.certificate_signing_request,
+                        is_ca=provider_certificate.certificate.is_ca,
                     ):
                         logger.debug("Certificate requested for different attributes - Skipping")
                         continue
@@ -1470,17 +1516,27 @@ class TLSCertificatesRequiresV4(Object):
         - The CSR public key does not match the private key.
         """
         for requirer_csr in self.get_csrs_from_requirer_relation_data():
-            if not self._csr_matches_certificate_request(requirer_csr):
-                self._remove_requirer_csr_from_relation_data(requirer_csr)
-                logger.info(
-                    "Removed CSR from relation data because \
-                        it did not match any certificate request"
+            if not self._csr_matches_certificate_request(
+                certificate_signing_request=requirer_csr.certificate_signing_request,
+                is_ca=requirer_csr.is_ca,
+            ):
+                self._remove_requirer_csr_from_relation_data(
+                    requirer_csr.certificate_signing_request
                 )
-            elif self.private_key and not requirer_csr.matches_private_key(self.private_key):
-                self._remove_requirer_csr_from_relation_data(requirer_csr)
                 logger.info(
-                    "Removed CSR from relation data because \
-                        it did not match the private key"
+                    "Removed CSR from relation data because it did not match any certificate request"  # noqa: E501
+                )
+            elif (
+                self.private_key
+                and not requirer_csr.certificate_signing_request.matches_private_key(
+                    self.private_key
+                )
+            ):
+                self._remove_requirer_csr_from_relation_data(
+                    requirer_csr.certificate_signing_request
+                )
+                logger.info(
+                    "Removed CSR from relation data because it did not match the private key"  # noqa: E501
                 )
 
     def _get_next_secret_expiry_time(
@@ -1617,6 +1673,7 @@ class TLSCertificatesProvidesV4(Object):
                 certificate_signing_request=CertificateSigningRequest.from_string(
                     csr.certificate_signing_request
                 ),
+                is_ca=csr.ca if csr.ca else False,
             )
             for csr in requirer_relation_data.certificate_signing_requests
         ]

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -417,7 +417,7 @@ class Certificate:
         try:
             is_ca = certificate_object.extensions.get_extension_for_oid(
                 ExtensionOID.BASIC_CONSTRAINTS
-            ).value.ca
+            ).value.ca  # type: ignore[reportAttributeAccessIssue]
         except x509.ExtensionNotFound:
             is_ca = False
 

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -1284,21 +1284,11 @@ class TLSCertificatesRequiresV4(Object):
         self, certificate_signing_request: CertificateSigningRequest, is_ca: bool
     ) -> bool:
         for certificate_request in self.certificate_requests:
-            logger.warning(
-                "TO DELETE: Relation Data Request: %s",
-                CertificateRequest.from_csr(
-                    certificate_signing_request,
-                    is_ca,
-                ),
-            )
-            logger.warning("TO DELETE: Certificate Request: %s", certificate_request)
             if certificate_request == CertificateRequest.from_csr(
                 certificate_signing_request,
                 is_ca,
             ):
-                logger.warning("TO DELETE: Match found")
                 return True
-        logger.warning("TO DELETE: No match found")
         return False
 
     def _certificate_requested(self, certificate_request: CertificateRequest) -> bool:

--- a/tests/unit/charms/tls_certificates_interface/v4/certificates.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/certificates.py
@@ -71,6 +71,7 @@ def generate_certificate(
     ca: str,
     ca_key: str,
     validity: int = 24 * 365,
+    is_ca: bool = False,
 ) -> str:
     """Generate a TLS certificate based on a CSR.
 
@@ -79,6 +80,7 @@ def generate_certificate(
         ca (str): CA Certificate
         ca_key (str): CA private key
         validity (int): Certificate validity (in hours)
+        is_ca (bool): Is the certificate a CA certificate
 
     Returns:
         str: Certificate
@@ -109,6 +111,12 @@ def generate_certificate(
         .not_valid_before(not_valid_before)
         .not_valid_after(not_valid_after)
     )
+
+    if is_ca:
+        certificate_builder = certificate_builder.add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
+        )
 
     certificate_builder._version = x509.Version.v3
     cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/src/charm.py
@@ -77,7 +77,7 @@ class DummyTLSCertificatesProviderCharm(CharmBase):
             csrs.append(
                 {
                     "csr": str(requirer_csr.certificate_signing_request),
-                    "is_ca": requirer_csr.certificate_signing_request.is_ca,
+                    "is_ca": requirer_csr.is_ca,
                 }
             )
         event.set_results(results={"csrs": csrs})
@@ -89,7 +89,7 @@ class DummyTLSCertificatesProviderCharm(CharmBase):
             certificate_requests.append(
                 {
                     "csr": str(outstanding_certificate_request.certificate_signing_request),
-                    "is_ca": outstanding_certificate_request.certificate_signing_request.is_ca,
+                    "is_ca": outstanding_certificate_request.is_ca,
                 }
             )
         event.set_results(results={"csrs": certificate_requests})

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/charmcraft.yaml
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/charmcraft.yaml
@@ -42,6 +42,9 @@ config:
     email_address:
       type: string
       description: Certificate email address
+    is_ca:
+      type: boolean
+      description: Is the certificate a CA certificate
 
 actions:
   regenerate-private-key:

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
@@ -46,6 +46,7 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
                 country_name=self._get_config_country_name(),
                 state_or_province_name=self._get_config_state_or_province_name(),
                 locality_name=self._get_config_locality_name(),
+                is_ca=self._get_config_is_ca(),
             )
         ]
 
@@ -76,7 +77,7 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
     def _get_config_common_name(self) -> str:
         return cast(str, self.model.config.get("common_name"))
 
-    def _get_config_sans_dns(self) -> FrozenSet[str] | None:
+    def _get_config_sans_dns(self) -> FrozenSet[str]:
         config_sans_dns = cast(str, self.model.config.get("sans_dns", ""))
         return frozenset(config_sans_dns.split(",") if config_sans_dns else [])
 
@@ -97,6 +98,9 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
 
     def _get_config_locality_name(self) -> Optional[str]:
         return cast(str, self.model.config.get("locality_name"))
+
+    def _get_config_is_ca(self) -> bool:
+        return cast(bool, self.model.config.get("is_ca", False))
 
 
 if __name__ == "__main__":

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
@@ -76,7 +76,7 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
     def _get_config_common_name(self) -> str:
         return cast(str, self.model.config.get("common_name"))
 
-    def _get_config_sans_dns(self) -> FrozenSet[str]:
+    def _get_config_sans_dns(self) -> FrozenSet[str] | None:
         config_sans_dns = cast(str, self.model.config.get("sans_dns", ""))
         return frozenset(config_sans_dns.split(",") if config_sans_dns else [])
 

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
@@ -273,7 +273,8 @@ def test_given_ca_certificate_attributes_when_generate_ca_then_ca_is_generated_c
     assert ca_certificate.sans_oid == frozenset()
 
 
-# Generate Certificate
+# # Generate Certificate
+
 
 def test_given_csr_when_generate_certificate_then_certificate_generated_with_requested_attributes():  # noqa: E501
     private_key = generate_private_key()
@@ -296,9 +297,48 @@ def test_given_csr_when_generate_certificate_then_certificate_generated_with_req
         ca=ca_certificate,
         ca_private_key=ca_private_key,
         validity=200,
+        is_ca=False,
     )
 
     assert certificate.common_name == "example.com"
+    assert certificate.is_ca is False
+    expected_expiry = datetime.now(timezone.utc) + timedelta(days=200)
+    assert certificate.expiry_time
+    assert abs(certificate.expiry_time - expected_expiry) <= timedelta(seconds=1)
+    assert certificate.sans_dns == frozenset(["example.com"])
+    assert certificate.sans_ip == frozenset()
+    assert certificate.sans_oid == frozenset()
+    assert certificate.email_address is None
+    assert certificate.country_name is None
+    assert certificate.locality_name == "wherever"
+
+
+def test_given_csr_for_ca_when_generate_certificate_then_certificate_generated_with_requested_attributes():  # noqa: E501
+    private_key = generate_private_key()
+    csr = generate_csr(
+        private_key=private_key,
+        common_name="example.com",
+        sans_dns=frozenset(["example.com"]),
+        locality_name="wherever",
+    )
+    ca_private_key = generate_private_key()
+    ca_certificate = generate_ca(
+        private_key=ca_private_key,
+        validity=365,
+        common_name="certifier.example.com",
+        sans_dns=frozenset(["certifier.example.com"]),
+    )
+
+    certificate = generate_certificate(
+        csr=csr,
+        ca=ca_certificate,
+        ca_private_key=ca_private_key,
+        validity=200,
+        is_ca=True,
+    )
+
+    assert certificate.common_name == "example.com"
+    assert certificate.is_ca is True
     expected_expiry = datetime.now(timezone.utc) + timedelta(days=200)
     assert certificate.expiry_time
     assert abs(certificate.expiry_time - expected_expiry) <= timedelta(seconds=1)

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
@@ -273,7 +273,7 @@ def test_given_ca_certificate_attributes_when_generate_ca_then_ca_is_generated_c
     assert ca_certificate.sans_oid == frozenset()
 
 
-# # Generate Certificate
+# Generate Certificate
 
 
 def test_given_csr_when_generate_certificate_then_certificate_generated_with_requested_attributes():  # noqa: E501


### PR DESCRIPTION
# Description

Fix an issue where requests for CA certificates were not managed correctly. The CertificateRequest was made for a CA certificate, the lib would create the correct CSR, then would remove the CSR from the relation databag thinking it's not a match.

## This is a major api change
Here we get rid of the `CSR.to_certificate_request` and replace it with the `CertificateRequest.from_csr`. Since this library is still in beta, we don't go with a major version bump. 

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
