### PR TITLE
fix: Backward compatibility issue with getting the CSR from Juju secret

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -318,7 +318,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 17
+LIBPATCH = 18
 
 PYDEPS = ["cryptography", "jsonschema"]
 

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -305,6 +305,7 @@ from ops.model import (
     ModelError,
     Relation,
     RelationDataContent,
+    Secret,
     SecretNotFoundError,
     Unit,
 )
@@ -1966,9 +1967,10 @@ class TLSCertificatesRequiresV3(Object):
         Args:
             event (SecretExpiredEvent): Juju event
         """
-        if not event.secret.label or not event.secret.label.startswith(f"{LIBID}-"):
+        csr = self._get_csr_from_secret(event.secret)
+        if not csr:
+            logger.error("Failed to get CSR from secret %s", event.secret.label)
             return
-        csr = event.secret.get_content()["csr"]
         provider_certificate = self._find_certificate_in_relation_data(csr)
         if not provider_certificate:
             # A secret expired but we did not find matching certificate. Cleaning up
@@ -2008,3 +2010,18 @@ class TLSCertificatesRequiresV3(Object):
                 continue
             return provider_certificate
         return None
+
+    def _get_csr_from_secret(self, secret: Secret) -> str:
+        """Extract the CSR from the secret label or content.
+
+        This function is a workaround to maintain backwards compatiblity
+        and fix the issue reported in
+        https://github.com/canonical/tls-certificates-interface/issues/228
+        """
+        if not (csr := secret.get_content().get("csr", "")):
+            # In versions <14 of the Lib we were storing the CSR in the label of the secret
+            # The CSR now is stored int the content of the secret, which was a breaking change
+            # Here we get the CSR if the secret was created by an app using libpatch 14 or lower
+            if secret.label and secret.label.startswith(f"{LIBID}-"):
+                csr = secret.label[len(f"{LIBID}-") :]
+        return csr

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
@@ -1706,6 +1706,22 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         with pytest.raises(RuntimeError):
             self.harness.get_secret_revisions(secret_id)
 
+    def test_given_csr_in_secret_label_and_no_matching_certificates_when_secret_expired_then_secret_revisions_are_removed(  # noqa: E501
+        self
+    ):
+        csr = "whatever csr"
+        certificate = "whatever certificate"
+        secret_id = self.harness.add_model_secret(
+            owner=self.harness.charm.unit.name, content={"certificate": certificate}
+        )
+        secret = self.harness.model.get_secret(id=secret_id)
+        secret.set_info(label=f"{LIBID}-{csr}")
+
+        self.harness.trigger_secret_expiration(secret_id, 0)
+
+        with pytest.raises(RuntimeError):
+            self.harness.get_secret_revisions(secret_id)
+
     @patch('cryptography.x509.load_pem_x509_certificate')
     def test_given_certificate_has_expiry_time_and_notification_time_recommended_by_provider_is_valid_when_get_provider_certificates_then_recommended_expiry_notification_time_is_used(  # noqa: E501
         self, patch_load_pem_x509_certificate

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
@@ -1579,7 +1579,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
 
         assert secret.get_info().expires == expiry_time
 
-    def test_given_secret_not_owned_by_lib_when_secret_expired_then_secret_revisions_are_not_removed(  # noqa: E501
+    def test_given_secret_does_not_have_the_csr_when_secret_expired_then_secret_revisions_are_not_removed(  # noqa: E501
         self,
     ):
         secret_id = self.harness.add_model_secret(


### PR DESCRIPTION
# Description

Fixes #228.

Adds a workaround function that would try to get the csr from the secret content and if it isn't there it would attempt to get it from the secret label as the lib was doing till version 3.14

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
