### PR TITLE
feat: add get_unsolicited_certificates to TLS provider class

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -318,7 +318,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 18
+LIBPATCH = 19
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -736,16 +736,16 @@ def calculate_expiry_notification_time(
     """
     if provider_recommended_notification_time is not None:
         provider_recommended_notification_time = abs(provider_recommended_notification_time)
-        provider_recommendation_time_delta = (
-            expiry_time - timedelta(hours=provider_recommended_notification_time)
+        provider_recommendation_time_delta = expiry_time - timedelta(
+            hours=provider_recommended_notification_time
         )
         if validity_start_time < provider_recommendation_time_delta:
             return provider_recommendation_time_delta
 
     if requirer_recommended_notification_time is not None:
         requirer_recommended_notification_time = abs(requirer_recommended_notification_time)
-        requirer_recommendation_time_delta = (
-            expiry_time - timedelta(hours=requirer_recommended_notification_time)
+        requirer_recommendation_time_delta = expiry_time - timedelta(
+            hours=requirer_recommended_notification_time
         )
         if validity_start_time < requirer_recommendation_time_delta:
             return requirer_recommendation_time_delta
@@ -1449,18 +1449,33 @@ class TLSCertificatesProvidesV3(Object):
         Returns:
             None
         """
-        provider_certificates = self.get_provider_certificates(relation_id)
-        requirer_csrs = self.get_requirer_csrs(relation_id)
+        provider_certificates = self.get_unsolicited_certificates(
+            relation_id=relation_id
+        )
+        for provider_certificate in provider_certificates:
+            self.on.certificate_revocation_request.emit(
+                certificate=provider_certificate.certificate,
+                certificate_signing_request=provider_certificate.csr,
+                ca=provider_certificate.ca,
+                chain=provider_certificate.chain,
+            )
+            self.remove_certificate(certificate=provider_certificate.certificate)
+
+    def get_unsolicited_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> List[ProviderCertificate]:
+        """Return provider certificates for which no certificate requests exists.
+
+        Those certificates should be revoked.
+        """
+        unsolicited_certificates: List[ProviderCertificate] = []
+        provider_certificates = self.get_provider_certificates(relation_id=relation_id)
+        requirer_csrs = self.get_requirer_csrs(relation_id=relation_id)
         list_of_csrs = [csr.csr for csr in requirer_csrs]
         for certificate in provider_certificates:
             if certificate.csr not in list_of_csrs:
-                self.on.certificate_revocation_request.emit(
-                    certificate=certificate.certificate,
-                    certificate_signing_request=certificate.csr,
-                    ca=certificate.ca,
-                    chain=certificate.chain,
-                )
-                self.remove_certificate(certificate=certificate.certificate)
+                unsolicited_certificates.append(certificate)
+        return unsolicited_certificates
 
     def get_outstanding_certificate_requests(
         self, relation_id: Optional[int] = None
@@ -1878,8 +1893,7 @@ class TLSCertificatesRequiresV3(Object):
                             "Removing secret with label %s",
                             f"{LIBID}-{csr_in_sha256_hex}",
                         )
-                        secret = self.model.get_secret(
-                            label=f"{LIBID}-{csr_in_sha256_hex}")
+                        secret = self.model.get_secret(label=f"{LIBID}-{csr_in_sha256_hex}")
                         secret.remove_all_revisions()
                     self.on.certificate_invalidated.emit(
                         reason="revoked",

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -1793,6 +1793,22 @@ class TLSCertificatesProvidesV4(Object):
                 certificates.append(certificate.to_provider_certificate(relation_id=relation.id))
         return certificates
 
+    def get_unsolicited_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> List[ProviderCertificate]:
+        """Return provider certificates for which no certificate requests exists.
+
+        Those certificates should be revoked.
+        """
+        unsolicited_certificates: List[ProviderCertificate] = []
+        provider_certificates = self.get_provider_certificates(relation_id=relation_id)
+        requirer_csrs = self.get_certificate_requests(relation_id=relation_id)
+        list_of_csrs = [csr.certificate_signing_request for csr in requirer_csrs]
+        for certificate in provider_certificates:
+            if certificate.certificate_signing_request not in list_of_csrs:
+                unsolicited_certificates.append(certificate)
+        return unsolicited_certificates
+
     def get_outstanding_certificate_requests(
         self, relation_id: Optional[int] = None
     ) -> List[RequirerCSR]:

--- a/tests/unit/charms/tls_certificates_interface/v3/certificates.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/certificates.py
@@ -41,8 +41,7 @@ def generate_private_key(
 
 
 def generate_ec_private_key(
-        curve: ec.EllipticCurve = ec.SECP256K1(),
-        password: Optional[bytes] = None
+    curve: ec.EllipticCurve = ec.SECP256K1(), password: Optional[bytes] = None
 ) -> bytes:
     """Generate a elliptic curve private key.
 
@@ -53,9 +52,7 @@ def generate_ec_private_key(
     Returns:
         bytes: Private Key
     """
-    private_key = ec.generate_private_key(
-        curve=curve
-    )
+    private_key = ec.generate_private_key(curve=curve)
     key_bytes = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3.py
@@ -321,9 +321,7 @@ def test_given_alt_names_when_generate_certificate_then_alt_names_are_correctly_
     )
 
     certificate_object = x509.load_pem_x509_certificate(certificate)
-    alt_names = certificate_object.extensions.get_extension_for_class(
-        x509.SubjectAlternativeName
-    )
+    alt_names = certificate_object.extensions.get_extension_for_class(x509.SubjectAlternativeName)
     alt_name_strings = [alt_name.value for alt_name in alt_names.value]
     assert len(alt_name_strings) == 2
     assert alt_name_1 in alt_name_strings
@@ -351,9 +349,7 @@ def test_given_sans_in_csr_and_alt_names_when_generate_certificate_then_alt_name
     certificate = generate_certificate(csr=csr, ca=ca, ca_key=ca_key, alt_names=src_alt_names)
 
     cert = x509.load_pem_x509_certificate(certificate)
-    result_all_sans = cert.extensions.get_extension_for_class(
-        x509.SubjectAlternativeName
-    )
+    result_all_sans = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
     result_sans_dns = sorted(result_all_sans.value.get_values_for_type(x509.DNSName))
 
     assert result_sans_dns == sorted(src_sans_dns + src_alt_names)
@@ -667,8 +663,8 @@ def test_given_provider_recommended_notification_time_when_calculate_expiry_noti
     validity_start_time = expiry_time - timedelta(hours=validity_start_time_in_hours)
     provider_recommended_notification_time = 24
     requirer_recommended_notification_time = 48
-    expected_notification_time = (
-        expiry_time - timedelta(hours=provider_recommended_notification_time)
+    expected_notification_time = expiry_time - timedelta(
+        hours=provider_recommended_notification_time
     )
     notification_time = calculate_expiry_notification_time(
         expiry_time=expiry_time,
@@ -685,8 +681,8 @@ def test_given_negative_provider_recommended_notification_time_when_calculate_ex
     validity_start_time = expiry_time - timedelta(hours=validity_start_time_in_hours)
     negative_provider_recommended_notification_time = 24
     requirer_recommended_notification_time = 48
-    expected_notification_time = (
-        expiry_time - timedelta(hours=abs(negative_provider_recommended_notification_time))
+    expected_notification_time = expiry_time - timedelta(
+        hours=abs(negative_provider_recommended_notification_time)
     )
     notification_time = calculate_expiry_notification_time(
         expiry_time=expiry_time,
@@ -703,8 +699,8 @@ def test_given_provider_recommended_notification_time_is_too_early_when_calculat
     validity_start_time = expiry_time - timedelta(hours=validity_start_time_in_hours)
     provider_recommended_notification_time = 241
     requirer_recommended_notification_time = 24
-    expected_notification_time = (
-        expiry_time - timedelta(hours=requirer_recommended_notification_time)
+    expected_notification_time = expiry_time - timedelta(
+        hours=requirer_recommended_notification_time
     )
     notification_time = calculate_expiry_notification_time(
         expiry_time=expiry_time,
@@ -721,8 +717,8 @@ def test_given_provider_recommended_notification_time_is_none_when_calcualte_exp
     validity_start_time = expiry_time - timedelta(hours=validity_start_time_in_hours)
     provider_recommended_notification_time = None
     requirer_recommended_notification_time = 24
-    expected_notification_time = (
-        expiry_time - timedelta(hours=requirer_recommended_notification_time)
+    expected_notification_time = expiry_time - timedelta(
+        hours=requirer_recommended_notification_time
     )
     notification_time = calculate_expiry_notification_time(
         expiry_time=expiry_time,
@@ -828,12 +824,14 @@ def test_given_localization_is_specified_when_generate_csr_then_csr_contains_loc
 
     csr_object = x509.load_pem_x509_csr(csr)
     assert csr_object.subject.get_attributes_for_oid(x509.NameOID.COUNTRY_NAME)[0].value == "CA"
-    assert csr_object.subject.get_attributes_for_oid(
-        x509.NameOID.STATE_OR_PROVINCE_NAME
-        )[0].value == "Quebec"
-    assert csr_object.subject.get_attributes_for_oid(
-        x509.NameOID.LOCALITY_NAME
-        )[0].value == "Montreal"
+    assert (
+        csr_object.subject.get_attributes_for_oid(x509.NameOID.STATE_OR_PROVINCE_NAME)[0].value
+        == "Quebec"
+    )
+    assert (
+        csr_object.subject.get_attributes_for_oid(x509.NameOID.LOCALITY_NAME)[0].value
+        == "Montreal"
+    )
 
 
 def test_given_ipv6_sans_when_generate_csr_then_csr_contains_ipv6_sans():

--- a/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/test_tls_certificates_v3_requires.py
@@ -752,7 +752,9 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     @patch("cryptography.x509.load_pem_x509_certificate")
     def test_given_csr_in_unit_relation_data_and_certificate_revoked_in_remote_relation_data_when_relation_changed_then_certificate_invalidated_event_with_reason_revoked_emitted(  # noqa: E501
-        self, patch_load_pem_x509_certificate, patch_on_certificate_invalidated,
+        self,
+        patch_load_pem_x509_certificate,
+        patch_on_certificate_invalidated,
     ):
         relation_id = self.create_certificates_relation()
         ca_certificate = "whatever certificate"
@@ -840,7 +842,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         assert certificate_available_event.ca == ca_certificate
         assert certificate_available_event.chain == chain
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")
     def test_given_csr_in_unit_relation_data_and_certificate_in_remote_relation_data_when_relation_changed_then_secret_is_added(  # noqa: E501
         self, patch_on_certificate_available, patch_load_pem_x509_certificate
@@ -887,7 +889,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         assert secret.get_content()["certificate"] == certificate
         assert secret.get_info().expires == expiry_time - timedelta(hours=168)
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")
     def test_given_csr_in_unit_relation_data_and_certificate_in_remote_relation_data_and_secret_already_exists_when_relation_changed_then_secret_is_updated(  # noqa: E501
         self, patch_on_certificate_available, patch_load_pem_x509_certificate
@@ -939,7 +941,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         assert secret.get_content(refresh=True)["certificate"] == certificate
         assert secret.get_info().expires == expiry_time - timedelta(hours=168)
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     def test_given_certificates_available_when_get_assigned_certificates_then_unit_certificates_returned_only(  # noqa: E501
         self, patch_load_pem_x509_certificate
     ):
@@ -1081,7 +1083,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         )
         assert len(self.harness.charm.certificates.get_certificate_signing_requests()) == 2
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     def test_given_csrs_created_when_get_fulfilled_csrs_only_then_correct_csrs_returned(
         self, patch_load_pem_x509_certificate
     ):
@@ -1132,10 +1134,9 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         assert len(output) == 1
         assert output[0].csr == "csr1"
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     def test_given_csrs_created_when_get_unfulfilled_csrs_only_then_correct_csrs_returned(
-        self,
-        patch_load_pem_x509_certificate
+        self, patch_load_pem_x509_certificate
     ):
         relation_id = self.create_certificates_relation()
 
@@ -1228,7 +1229,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         )
         assert len(output) == 0
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     def test_given_no_expired_certificates_in_relation_data_when_get_expiring_certificates_then_no_certificates_returned(  # noqa: E501
         self, patch_load_pem_x509_certificate
     ):
@@ -1272,7 +1273,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         all_certs = self.harness.charm.certificates.get_expiring_certificates()
         assert len(all_certs) == 0
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     @patch(f"{LIB_DIR}.calculate_expiry_notification_time")
     def test_given_certificate_about_to_expire_in_relation_data_when_get_expiring_certificates_then_correct_certificates_returned(  # noqa: E501
         self,
@@ -1322,7 +1323,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         assert len(all_certs) > 0
         assert all_certs[0].certificate == certificate
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_in_relation_data_when_secret_expired_then_certificate_invalidated_event_with_reason_expired_emitted(  # noqa: E501
         self, patch_certificate_invalidated, patch_load_pem_x509_certificate
@@ -1373,7 +1374,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_and_other_certificates_in_relation_data_when_secret_expired_then_certificate_invalidated_event_with_reason_expired_emitted_once(  # noqa: E501
         self, patch_certificate_invalidated, patch_load_pem_x509_certificate
@@ -1430,7 +1431,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_invalidated")
     def test_given_expired_certificate_in_relation_data_when_secret_expired_then_secret_revisions_are_removed(  # noqa: E501
         self, patch_certificate_invalidated, patch_load_pem_x509_certificate
@@ -1480,7 +1481,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         with pytest.raises(RuntimeError):
             self.harness.get_secret_revisions(secret_id)
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_expiring")
     def test_given_almost_expiring_certificate_in_relation_data_when_secret_expired_then_certificate_expiring_event_emitted(  # noqa: E501
         self, patch_certificate_expiring, patch_load_pem_x509_certificate
@@ -1531,7 +1532,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         event_data = args[0]
         assert event_data.certificate == certificate
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     @patch(f"{BASE_CHARM_DIR}._on_certificate_expiring")
     def test_given_almost_expiring_certificate_in_relation_data_when_secret_expired_then_secret_expiry_is_set_to_certificate_expiry(  # noqa: E501
         self, patch_certificate_expiring, patch_load_pem_x509_certificate
@@ -1592,7 +1593,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
 
         assert self.harness.get_secret_revisions(secret_id)
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     def test_given_certificate_not_found_in_relation_data_when_secret_expired_then_secret_revisions_are_removed(  # noqa: E501
         self, patch_load_pem_x509_certificate
     ):
@@ -1626,11 +1627,8 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         expiry_time = start_time - timedelta(seconds=10)
 
         patch_load_pem_x509_certificate.return_value = self.setup_mock_certificate_object(
-
             expiry_time=expiry_time,
-
             start_time=start_time,
-
         )
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1652,7 +1650,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         with pytest.raises(RuntimeError):
             self.harness.get_secret_revisions(secret_id)
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     def test_given_certificate_invalid_in_relation_data_when_secret_expired_then_secret_revisions_are_removed(  # noqa: E501
         self, patch_load_pem_x509_certificate
     ):
@@ -1686,11 +1684,8 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         expiry_time = start_time - timedelta(seconds=10)
 
         patch_load_pem_x509_certificate.return_value = self.setup_mock_certificate_object(
-
             expiry_time=expiry_time,
-
             start_time=start_time,
-
         )
         self.harness.update_relation_data(
             relation_id=relation_id,
@@ -1707,7 +1702,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
             self.harness.get_secret_revisions(secret_id)
 
     def test_given_csr_in_secret_label_and_no_matching_certificates_when_secret_expired_then_secret_revisions_are_removed(  # noqa: E501
-        self
+        self,
     ):
         csr = "whatever csr"
         certificate = "whatever certificate"
@@ -1722,7 +1717,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         with pytest.raises(RuntimeError):
             self.harness.get_secret_revisions(secret_id)
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     def test_given_certificate_has_expiry_time_and_notification_time_recommended_by_provider_is_valid_when_get_provider_certificates_then_recommended_expiry_notification_time_is_used(  # noqa: E501
         self, patch_load_pem_x509_certificate
     ):
@@ -1759,8 +1754,8 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
             expiry_time=expiry_time,
             start_time=start_time,
         )
-        expected_expiry_notification_time = (
-            expiry_time - timedelta(hours=provider_recommended_notification_time)
+        expected_expiry_notification_time = expiry_time - timedelta(
+            hours=provider_recommended_notification_time
         )
 
         self.harness.update_relation_data(
@@ -1772,7 +1767,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         assert len(certs) == 1
         assert certs[0].expiry_notification_time == expected_expiry_notification_time
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     def test_given_certificate_has_expiry_time_and_no_notification_time_recommended_by_provider_when_get_provider_certificates_then_different_notification_time_is_used(  # noqa: E501
         self, patch_load_pem_x509_certificate
     ):
@@ -1809,8 +1804,8 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
             start_time=start_time,
         )
         assert self.harness.charm.certificates.expiry_notification_time
-        expected_expiry_notification_time = (
-            expiry_time - timedelta(hours=self.harness.charm.certificates.expiry_notification_time)
+        expected_expiry_notification_time = expiry_time - timedelta(
+            hours=self.harness.charm.certificates.expiry_notification_time
         )
 
         self.harness.update_relation_data(
@@ -1822,7 +1817,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         assert len(certs) == 1
         assert certs[0].expiry_notification_time == expected_expiry_notification_time  # noqa: E501
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     def test_given_certificate_has_expiry_time_and_provider_recommended_notification_time_too_long_when_get_provider_certificates_then_recommended_expiry_notification_time_is_used(  # noqa: E501
         self, patch_load_pem_x509_certificate
     ):
@@ -1861,8 +1856,8 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
             start_time=start_time,
         )
         assert self.harness.charm.certificates.expiry_notification_time
-        expected_expiry_notification_time = (
-            expiry_time - timedelta(hours=self.harness.charm.certificates.expiry_notification_time)
+        expected_expiry_notification_time = expiry_time - timedelta(
+            hours=self.harness.charm.certificates.expiry_notification_time
         )
 
         self.harness.update_relation_data(
@@ -1874,7 +1869,7 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
         assert len(certs) == 1
         assert certs[0].expiry_notification_time == expected_expiry_notification_time
 
-    @patch('cryptography.x509.load_pem_x509_certificate')
+    @patch("cryptography.x509.load_pem_x509_certificate")
     def test_given_certificate_has_expiry_time_and_no_valid_requirer_recommended_notification_time_too_long_when_get_provider_certificates_then_expiry_notification_time_is_calculated(  # noqa: E501
         self, patch_load_pem_x509_certificate
     ):
@@ -1891,7 +1886,9 @@ class TestTLSCertificatesRequiresV3(unittest.TestCase):
             app_or_unit=self.harness.charm.unit.name,
             key_values=unit_relation_data,
         )
-        recommended_expiry_notification_time = self.harness.charm.certificates.expiry_notification_time  # noqa: E501
+        recommended_expiry_notification_time = (
+            self.harness.charm.certificates.expiry_notification_time
+        )  # noqa: E501
         remote_app_relation_data = {
             "certificates": json.dumps(
                 [

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/charmcraft.yaml
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/charmcraft.yaml
@@ -15,6 +15,8 @@ provides:
 actions:
   get-certificate-requests:
     description: Get the certificate requests from the requirers
+  get-unsolicited-certificates:
+    description: Get the unsolicited certificates from the requirers
   get-outstanding-certificate-requests:
     description: Get the outstanding certificate requests from the requirers
   get-issued-certificates:

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/src/charm.py
@@ -51,6 +51,10 @@ class DummyTLSCertificatesProviderCharm(CharmBase):
             self.on.get_certificate_requests_action, self._on_get_certificate_rquests_action
         )
         self.framework.observe(
+            self.on.get_unsolicited_certificates_action,
+            self._on_get_unsolicited_certificates_action,
+        )
+        self.framework.observe(
             self.on.get_outstanding_certificate_requests_action,
             self._on_get_outstanding_certificate_requests_action,
         )
@@ -81,6 +85,17 @@ class DummyTLSCertificatesProviderCharm(CharmBase):
                 }
             )
         event.set_results(results={"csrs": csrs})
+
+    def _on_get_unsolicited_certificates_action(self, event: ActionEvent) -> None:
+        unsolicited_certificates = self.certificates.get_unsolicited_certificates()
+        certificates = []
+        for unsolicited_certificate in unsolicited_certificates:
+            certificates.append(
+                {
+                    "certificate": str(unsolicited_certificate.certificate),
+                }
+            )
+        event.set_results(results={"certificates": certificates})
 
     def _on_get_outstanding_certificate_requests_action(self, event: ActionEvent) -> None:
         outstanding_certificate_requests = self.certificates.get_outstanding_certificate_requests()


### PR DESCRIPTION
# Description

Add a `get_unsolicited_certificates` method for the provider side of the TLS certificates interface.

This method is needed in TLS constraints (in this PR):
- https://github.com/canonical/tls-constraints-operator/pull/114

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
