### PR TITLE
feat: change validity type from int to timedelta [v4]

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -862,7 +862,7 @@ def generate_csr(  # noqa: C901
 
 def generate_ca(
     private_key: PrivateKey,
-    validity: int,
+    validity: timedelta,
     common_name: str,
     sans_dns: Optional[FrozenSet[str]] = frozenset(),
     sans_ip: Optional[FrozenSet[str]] = frozenset(),
@@ -878,7 +878,7 @@ def generate_ca(
 
     Args:
         private_key (PrivateKey): Private key
-        validity (int): Certificate validity time (in days)
+        validity (timedelta): Certificate validity time
         common_name (str): Common Name that can be an IP or a Full Qualified Domain Name (FQDN).
         sans_dns (FrozenSet[str]): DNS Subject Alternative Names
         sans_ip (FrozenSet[str]): IP Subject Alternative Names
@@ -945,7 +945,7 @@ def generate_ca(
         .public_key(private_key_object.public_key())
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.now(timezone.utc))
-        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
+        .not_valid_after(datetime.now(timezone.utc) + validity)
         .add_extension(x509.SubjectAlternativeName(set(_sans)), critical=False)
         .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
         .add_extension(
@@ -971,7 +971,7 @@ def generate_certificate(
     csr: CertificateSigningRequest,
     ca: Certificate,
     ca_private_key: PrivateKey,
-    validity: int,
+    validity: timedelta,
     is_ca: bool = False,
 ) -> Certificate:
     """Generate a TLS certificate based on a CSR.
@@ -980,7 +980,7 @@ def generate_certificate(
         csr (CertificateSigningRequest): CSR
         ca (Certificate): CA Certificate
         ca_private_key (PrivateKey): CA private key
-        validity (int): Certificate validity (in days)
+        validity (timedelta): Certificate validity time
         is_ca (bool): Whether the certificate is a CA certificate
 
     Returns:
@@ -999,7 +999,7 @@ def generate_certificate(
         .public_key(csr_object.public_key())
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.now(timezone.utc))
-        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
+        .not_valid_after(datetime.now(timezone.utc) + validity)
     )
     extensions = _get_certificate_request_extensions(
         authority_key_identifier=ca_pem.extensions.get_extension_for_class(

--- a/tests/unit/charms/tls_certificates_interface/v4/certificates.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/certificates.py
@@ -70,7 +70,7 @@ def generate_certificate(
     csr: str,
     ca: str,
     ca_key: str,
-    validity: int = 24 * 365,
+    validity: timedelta = timedelta(days=365),
     is_ca: bool = False,
 ) -> str:
     """Generate a TLS certificate based on a CSR.
@@ -79,7 +79,7 @@ def generate_certificate(
         csr (str): CSR
         ca (str): CA Certificate
         ca_key (str): CA private key
-        validity (int): Certificate validity (in hours)
+        validity (timedelta): Certificate validity
         is_ca (bool): Is the certificate a CA certificate
 
     Returns:
@@ -96,12 +96,12 @@ def generate_certificate(
         ]
     )
 
-    if validity > 0:
+    if validity > timedelta(0):
         not_valid_before = datetime.now(timezone.utc)
-        not_valid_after = datetime.now(timezone.utc) + timedelta(hours=validity)
+        not_valid_after = datetime.now(timezone.utc) + validity
     else:
-        not_valid_before = datetime.now(timezone.utc) + timedelta(hours=validity)
-        not_valid_after = datetime.now(timezone.utc) - timedelta(seconds=1)
+        not_valid_before = datetime.now(timezone.utc) + validity
+        not_valid_after = datetime.now(timezone.utc) - validity
     certificate_builder = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -126,7 +126,7 @@ def generate_certificate(
 def generate_ca(
     private_key: str,
     common_name: str,
-    validity: int = 365,
+    validity: timedelta = timedelta(days=365),
 ) -> str:
     """Generate a CA Certificate.
 
@@ -158,7 +158,7 @@ def generate_ca(
         .public_key(private_key_object.public_key())  # type: ignore[arg-type]
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.now(timezone.utc))
-        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
+        .not_valid_after(datetime.now(timezone.utc) + validity)
         .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
         .add_extension(
             x509.AuthorityKeyIdentifier(

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
@@ -246,7 +246,7 @@ def test_given_ca_certificate_attributes_when_generate_ca_then_ca_is_generated_c
 
     ca_certificate = generate_ca(
         private_key=private_key,
-        validity=365,
+        validity=timedelta(days=365),
         common_name="certifier.example.com",
         sans_dns=frozenset(["certifier.example.com"]),
         sans_ip=frozenset(["1.2.3.4"]),
@@ -287,7 +287,7 @@ def test_given_csr_when_generate_certificate_then_certificate_generated_with_req
     ca_private_key = generate_private_key()
     ca_certificate = generate_ca(
         private_key=ca_private_key,
-        validity=365,
+        validity=timedelta(days=365),
         common_name="certifier.example.com",
         sans_dns=frozenset(["certifier.example.com"]),
     )
@@ -296,7 +296,7 @@ def test_given_csr_when_generate_certificate_then_certificate_generated_with_req
         csr=csr,
         ca=ca_certificate,
         ca_private_key=ca_private_key,
-        validity=200,
+        validity=timedelta(days=200),
         is_ca=False,
     )
 
@@ -324,7 +324,7 @@ def test_given_csr_for_ca_when_generate_certificate_then_certificate_generated_w
     ca_private_key = generate_private_key()
     ca_certificate = generate_ca(
         private_key=ca_private_key,
-        validity=365,
+        validity=timedelta(days=365),
         common_name="certifier.example.com",
         sans_dns=frozenset(["certifier.example.com"]),
     )
@@ -333,7 +333,7 @@ def test_given_csr_for_ca_when_generate_certificate_then_certificate_generated_w
         csr=csr,
         ca=ca_certificate,
         ca_private_key=ca_private_key,
-        validity=200,
+        validity=timedelta(days=200),
         is_ca=True,
     )
 

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
@@ -172,24 +172,26 @@ class TestTLSCertificatesRequiresV4:
 
         state_out = self.ctx.run(self.ctx.on.relation_changed(certificates_relation), state_in)
 
-        assert state_out.relations == frozenset({
-            scenario.Relation(
-                id=certificates_relation.id,
-                endpoint="certificates",
-                interface="tls-certificates",
-                remote_app_name="certificate-requirer",
-                local_unit_data={
-                    "certificate_signing_requests": json.dumps(
-                        [
-                            {
-                                "certificate_signing_request": csr,
-                                "ca": True,
-                            }
-                        ]
-                    )
-                },
-            ),
-        })
+        assert state_out.relations == frozenset(
+            {
+                scenario.Relation(
+                    id=certificates_relation.id,
+                    endpoint="certificates",
+                    interface="tls-certificates",
+                    remote_app_name="certificate-requirer",
+                    local_unit_data={
+                        "certificate_signing_requests": json.dumps(
+                            [
+                                {
+                                    "certificate_signing_request": csr,
+                                    "ca": True,
+                                }
+                            ]
+                        )
+                    },
+                ),
+            }
+        )
 
     def test_given_certificate_in_provider_relation_data_when_relation_changed_then_certificate_available_event_is_emitted(  # noqa: E501
         self,
@@ -866,7 +868,7 @@ class TestTLSCertificatesRequiresV4:
             ca_key=provider_private_key,
             csr=csr,
             ca=provider_ca_certificate,
-            validity=1,
+            validity=datetime.timedelta(hours=1),
         )
 
         new_csr = generate_csr(


### PR DESCRIPTION
# Description

Here we change the validity type from `int` to `timedelta` when generating certificates.

## Rationale

This allows for more granular certificate expiry date and simplifies generating certificates for times shorter than 1 day.  This feature was requested in #238. Here we only address it for v4, a separe PR should take care of it for v3 where we will need to care about compatibility and keep on supporting ints.

## This is a breaking change

This is a breaking change but since the lib v4 is not yet generally available, it's the right time to do it.


## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
