### PR TITLE
chore: improve variable naming for computing certificate expiry

### DIFF
--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
@@ -90,77 +90,77 @@ def test_given_key_size_provided_when_generate_private_key_then_private_key_is_g
 
 
 def test_given_provider_recommended_notification_time_when_calculate_expiry_notification_time_then_returns_provider_recommendation():  # noqa: E501
-    expiry_time = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    validity_start_time_in_hours = 240
-    validity_start_time = expiry_time - timedelta(hours=validity_start_time_in_hours)
+    not_valid_after = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    not_valid_before_in_hours = 240
+    not_valid_before = not_valid_after - timedelta(hours=not_valid_before_in_hours)
     provider_recommended_notification_time = 24
-    expected_notification_time = expiry_time - timedelta(
+    expected_notification_time = not_valid_after - timedelta(
         hours=provider_recommended_notification_time
     )
     notification_time = calculate_expiry_notification_time(
-        expiry_time=expiry_time,
-        validity_start_time=validity_start_time,
+        not_valid_after=not_valid_after,
+        not_valid_before=not_valid_before,
         provider_recommended_notification_time=provider_recommended_notification_time,
     )
     assert notification_time == expected_notification_time
 
 
 def test_given_negative_provider_recommended_notification_time_when_calculate_expiry_notification_time_then_returns_provider_recommendation():  # noqa: E501
-    expiry_time = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    validity_start_time_in_hours = 240
-    validity_start_time = expiry_time - timedelta(hours=validity_start_time_in_hours)
+    not_valid_after = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    not_valid_before_in_hours = 240
+    not_valid_before = not_valid_after - timedelta(hours=not_valid_before_in_hours)
     negative_provider_recommended_notification_time = 24
-    expected_notification_time = expiry_time - timedelta(
+    expected_notification_time = not_valid_after - timedelta(
         hours=abs(negative_provider_recommended_notification_time)
     )
     notification_time = calculate_expiry_notification_time(
-        expiry_time=expiry_time,
-        validity_start_time=validity_start_time,
+        not_valid_after=not_valid_after,
+        not_valid_before=not_valid_before,
         provider_recommended_notification_time=negative_provider_recommended_notification_time,
     )
     assert notification_time == expected_notification_time
 
 
 def test_given_requirer_and_provider_recommendations_are_invalid_when_calculate_expiry_notification_time_then_returns_calculated_notification_time():  # noqa: E501
-    expiry_time = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    validity_start_time_in_hours = 240
-    validity_start_time = expiry_time - timedelta(hours=validity_start_time_in_hours)
+    not_valid_after = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    not_valid_before_in_hours = 240
+    not_valid_before = not_valid_after - timedelta(hours=not_valid_before_in_hours)
     provider_recommended_notification_time = None
     calculated_hours = 80
-    expected_notification_time = expiry_time - timedelta(hours=calculated_hours)
+    expected_notification_time = not_valid_after - timedelta(hours=calculated_hours)
     notification_time = calculate_expiry_notification_time(
-        expiry_time=expiry_time,
-        validity_start_time=validity_start_time,
+        not_valid_after=not_valid_after,
+        not_valid_before=not_valid_before,
         provider_recommended_notification_time=provider_recommended_notification_time,
     )
     assert notification_time == expected_notification_time
 
 
 def test_given_negative_requirer_and_provider_recommendations_are_invalid_when_calculate_expiry_notification_time_then_returns_calculated_notification_time():  # noqa: E501
-    expiry_time = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    validity_start_time_in_hours = 240
-    validity_start_time = expiry_time - timedelta(hours=validity_start_time_in_hours)
+    not_valid_after = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    not_valid_before_in_hours = 240
+    not_valid_before = not_valid_after - timedelta(hours=not_valid_before_in_hours)
     provider_recommended_notification_time = None
     calculated_hours = 80
-    expected_notification_time = expiry_time - timedelta(hours=calculated_hours)
+    expected_notification_time = not_valid_after - timedelta(hours=calculated_hours)
     notification_time = calculate_expiry_notification_time(
-        expiry_time=expiry_time,
-        validity_start_time=validity_start_time,
+        not_valid_after=not_valid_after,
+        not_valid_before=not_valid_before,
         provider_recommended_notification_time=provider_recommended_notification_time,
     )
     assert notification_time == expected_notification_time
 
 
 def test_given_validity_time_is_too_short_when_calculate_expiry_notification_time_then_returns_calculated_notification_time():  # noqa: E501
-    expiry_time = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    validity_start_time_in_hours = 3
-    validity_start_time = expiry_time - timedelta(hours=validity_start_time_in_hours)
+    not_valid_after = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    not_valid_before_in_hours = 3
+    not_valid_before = not_valid_after - timedelta(hours=not_valid_before_in_hours)
     provider_recommended_notification_time = 24
     calculated_hours = 1
-    expected_notification_time = expiry_time - timedelta(hours=calculated_hours)
+    expected_notification_time = not_valid_after - timedelta(hours=calculated_hours)
     notification_time = calculate_expiry_notification_time(
-        expiry_time=expiry_time,
-        validity_start_time=validity_start_time,
+        not_valid_after=not_valid_after,
+        not_valid_before=not_valid_before,
         provider_recommended_notification_time=provider_recommended_notification_time,
     )
     assert notification_time == expected_notification_time


### PR DESCRIPTION
# Description

While troubleshooting an issue with certificate expiry, I struggled understanding the `calculate_expiry_notification_time`, mainly because of the name of variables and their docstring. Here we use the more commonly used `not_valid_before` and `not_valid_after` variable names instead.

We also remove the word `hours` as those could be minutes/years, it does not matter.

There is no change in the actual behavior.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
