### PR TITLE
feat: Adds a function to allow certificate renewal

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -1069,12 +1069,12 @@ class TLSCertificatesRequiresV4(Object):
         secret_label = self._get_csr_secret_label(certificate_signing_request)
         try:
             secret = self.model.get_secret(label=secret_label)
-            current_csr = secret.get_content(refresh=True)["csr"]
-            if current_csr != str(certificate_signing_request):
-                logger.info("No matching CSR found - Skipping")
-                return
         except SecretNotFoundError:
-            logger.info("Failed to get CSR from secret - Skipping renewal")
+            logger.warning("No matching secret found - Skipping renewal")
+            return
+        current_csr = secret.get_content(refresh=True).get("csr", "")
+        if current_csr != str(certificate_signing_request):
+            logger.warning("No matching CSR found - Skipping renewal")
             return
         self._renew_certificate_request(certificate_signing_request)
         secret.remove_all_revisions()

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -1064,10 +1064,7 @@ class TLSCertificatesRequiresV4(Object):
         event.secret.remove_all_revisions()
 
     def renew_certificate(self, certificate: ProviderCertificate) -> None:
-        """Request the renewal of the certificate matching the given certificate request.
-
-        The requirer can ask for the renewal using a CSR or a certificate.
-        """
+        """Request the renewal of the provided certificate."""
         certificate_signing_request = certificate.certificate_signing_request
         secret_label = self._get_csr_secret_label(certificate_signing_request)
         try:

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -1063,14 +1063,17 @@ class TLSCertificatesRequiresV4(Object):
         self._renew_certificate_request(csr)
         event.secret.remove_all_revisions()
 
-    def renew_certificate(self, csr: str) -> None:
-        """Request the renewal of the certificate matching the given certificate request."""
-        certificate_signing_request = CertificateSigningRequest.from_string(csr)
+    def renew_certificate(self, certificate: ProviderCertificate) -> None:
+        """Request the renewal of the certificate matching the given certificate request.
+
+        The requirer can ask for the renewal using a CSR or a certificate.
+        """
+        certificate_signing_request = certificate.certificate_signing_request
         secret_label = self._get_csr_secret_label(certificate_signing_request)
         try:
             secret = self.model.get_secret(label=secret_label)
             current_csr = secret.get_content(refresh=True)["csr"]
-            if current_csr != csr:
+            if current_csr != str(certificate_signing_request):
                 logger.info("No matching CSR found - Skipping")
                 return
         except SecretNotFoundError:

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/charmcraft.yaml
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/charmcraft.yaml
@@ -51,3 +51,5 @@ actions:
     description: Regenerate the private key
   get-certificate:
     description: Get the certificate
+  renew-certificates:
+    description: Renew the certificates

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
@@ -32,6 +32,9 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
             self.on.regenerate_private_key_action, self._on_regenerate_private_key_action
         )
         self.framework.observe(self.on.get_certificate_action, self._on_get_certificate_action)
+        self.framework.observe(
+            self.on.renew_certificates_action, self._on_renew_certificates_action
+        )
 
     def _get_certificate_requests(self) -> List[CertificateRequest]:
         if not self._get_config_common_name():
@@ -72,6 +75,18 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
                 "ca": str(certificate.ca),
                 "csr": str(certificate.certificate_signing_request),
             }
+        )
+
+    def _on_renew_certificates_action(self, event: ActionEvent) -> None:
+        certificate, _ = self.certificates.get_assigned_certificate(
+            certificate_request=self._get_certificate_requests()[0]
+        )
+        if not certificate:
+            event.fail("Not certificates available")
+            return
+        csr = str(certificate.certificate_signing_request)
+        self.certificates.renew_certificate(
+            csr=csr,
         )
 
     def _get_config_common_name(self) -> str:

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
@@ -84,9 +84,8 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
         if not certificate:
             event.fail("Not certificates available")
             return
-        csr = str(certificate.certificate_signing_request)
         self.certificates.renew_certificate(
-            csr=csr,
+            certificate=certificate,
         )
 
     def _get_config_common_name(self) -> str:

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
@@ -965,3 +965,118 @@ class TestTLSCertificatesRequiresV4:
                 )
             }
         )
+
+    @patch(LIB_DIR + ".CertificateRequest.generate_csr")
+    def test_given_certificate_when_renew_certificate_then_new_certificate_is_requested(
+        self, patch_generate_csr
+    ):
+        private_key = generate_private_key()
+        csr = generate_csr(
+            private_key=private_key,
+            common_name="example.com",
+        )
+        csr_in_sha256_hex = get_sha256_hex(csr)
+        provider_private_key = generate_private_key()
+        provider_ca_certificate = generate_ca(
+            private_key=provider_private_key,
+            common_name="example.com",
+        )
+        certificate = generate_certificate(
+            ca_key=provider_private_key,
+            csr=csr,
+            ca=provider_ca_certificate,
+            validity=datetime.timedelta(hours=1),
+        )
+
+        new_csr = generate_csr(
+            private_key=private_key,
+            common_name="example.com",
+        )
+        assert csr != new_csr
+        patch_generate_csr.return_value = new_csr
+
+        private_key_secret = Secret(
+            {"private-key": private_key},
+            label=f"{LIBID}-private-key-0",
+            owner="unit",
+        )
+
+        certificate_secret = Secret(
+            {
+                "certificate": certificate,
+                "csr": csr,
+            },
+            label=f"{LIBID}-certificate-0-{csr_in_sha256_hex}",
+            owner="unit",
+            expire=datetime.datetime.now() - datetime.timedelta(minutes=1),
+        )
+
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+            local_unit_data={
+                "certificate_signing_requests": json.dumps(
+                    [
+                        {
+                            "certificate_signing_request": csr,
+                            "ca": False,
+                        }
+                    ]
+                )
+            },
+            remote_app_data={
+                "certificates": json.dumps(
+                    [
+                        {
+                            "certificate": certificate,
+                            "certificate_signing_request": csr,
+                            "ca": provider_ca_certificate,
+                        }
+                    ]
+                ),
+            },
+        )
+
+        state_in = scenario.State(
+            config={"common_name": "example.com"},
+            relations={certificates_relation},
+            secrets={
+                private_key_secret,
+                certificate_secret,
+            },
+        )
+
+        state_out = self.ctx.run(self.ctx.on.action("renew-certificates"), state_in)
+
+        assert state_out.relations == frozenset(
+            {
+                scenario.Relation(
+                    id=certificates_relation.id,
+                    endpoint="certificates",
+                    interface="tls-certificates",
+                    remote_app_name="certificate-requirer",
+                    local_unit_data={
+                        "certificate_signing_requests": json.dumps(
+                            [
+                                {
+                                    "certificate_signing_request": new_csr,
+                                    "ca": False,
+                                }
+                            ]
+                        )
+                    },
+                    remote_app_data={
+                        "certificates": json.dumps(
+                            [
+                                {
+                                    "certificate": certificate,
+                                    "certificate_signing_request": csr,
+                                    "ca": provider_ca_certificate,
+                                }
+                            ]
+                        ),
+                    },
+                )
+            }
+        )


### PR DESCRIPTION
# Description

This PR allows requirer charms to ask for their certificates to be renewed before those actually expire.
This was required for [this](https://github.com/canonical/vault-k8s-operator/issues/500) fix in Vault.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
