### PR TITLE
chore: Rename CertificateRequest and RequirerCSR

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -47,7 +47,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 10
 
 PYDEPS = ["cryptography", "pydantic"]
 
@@ -424,8 +424,8 @@ class CertificateSigningRequest:
 
 
 @dataclass(frozen=True)
-class CertificateRequest:
-    """This class represents a certificate request.
+class CertificateRequestAttributes:
+    """A representation of the certificate request attributes.
 
     This class should be used inside the requirer charm to specify the requested
     attributes for the certificate.
@@ -477,7 +477,7 @@ class CertificateRequest:
 
     @classmethod
     def from_csr(cls, csr: CertificateSigningRequest, is_ca: bool):
-        """Create a CertificateRequest object from a CSR."""
+        """Create a CertificateRequestAttributes object from a CSR."""
         return cls(
             common_name=csr.common_name,
             sans_dns=csr.sans_dns,
@@ -523,8 +523,8 @@ class ProviderCertificate:
 
 
 @dataclass(frozen=True)
-class RequirerCSR:
-    """This class represents a certificate signing request requested by the TLS requirer."""
+class RequirerRequest:
+    """This class represents a certificate signing request requested by a specific TLS requirer."""
 
     relation_id: int
     certificate_signing_request: CertificateSigningRequest
@@ -996,7 +996,7 @@ class TLSCertificatesRequiresV4(Object):
         self,
         charm: CharmBase,
         relationship_name: str,
-        certificate_requests: List[CertificateRequest],
+        certificate_requests: List[CertificateRequestAttributes],
         mode: Mode = Mode.UNIT,
         refresh_events: List[BoundEvent] = [],
     ):
@@ -1005,7 +1005,8 @@ class TLSCertificatesRequiresV4(Object):
         Args:
             charm (CharmBase): The charm instance to relate to.
             relationship_name (str): The name of the relation that provides the certificates.
-            certificate_requests (List[CertificateRequest]): A list of certificate requests.
+            certificate_requests (List[CertificateRequestAttributes]):
+                A list of CertificateRequestAttributes with the attributes of the certificate requests.
             mode (Mode): Whether to use unit or app certificates mode. Default is Mode.UNIT.
             refresh_events (List[BoundEvent]): A list of events to trigger a refresh of
               the certificates.
@@ -1149,14 +1150,14 @@ class TLSCertificatesRequiresV4(Object):
         self, certificate_signing_request: CertificateSigningRequest, is_ca: bool
     ) -> bool:
         for certificate_request in self.certificate_requests:
-            if certificate_request == CertificateRequest.from_csr(
+            if certificate_request == CertificateRequestAttributes.from_csr(
                 certificate_signing_request,
                 is_ca,
             ):
                 return True
         return False
 
-    def _certificate_requested(self, certificate_request: CertificateRequest) -> bool:
+    def _certificate_requested(self, certificate_request: CertificateRequestAttributes) -> bool:
         if not self.private_key:
             return False
         csr = self._certificate_requested_for_attributes(certificate_request)
@@ -1168,17 +1169,17 @@ class TLSCertificatesRequiresV4(Object):
 
     def _certificate_requested_for_attributes(
         self,
-        certificate_request: CertificateRequest,
-    ) -> Optional[RequirerCSR]:
+        certificate_request: CertificateRequestAttributes,
+    ) -> Optional[RequirerRequest]:
         for requirer_csr in self.get_csrs_from_requirer_relation_data():
-            if certificate_request == CertificateRequest.from_csr(
+            if certificate_request == CertificateRequestAttributes.from_csr(
                 requirer_csr.certificate_signing_request,
                 requirer_csr.is_ca,
             ):
                 return requirer_csr
         return None
 
-    def get_csrs_from_requirer_relation_data(self) -> List[RequirerCSR]:
+    def get_csrs_from_requirer_relation_data(self) -> List[RequirerRequest]:
         """Return list of requirer's CSRs from relation data."""
         if self.mode == Mode.APP and not self.model.unit.is_leader():
             logger.debug("Not a leader unit - Skipping")
@@ -1196,7 +1197,7 @@ class TLSCertificatesRequiresV4(Object):
         requirer_csrs = []
         for csr in requirer_relation_data.certificate_signing_requests:
             requirer_csrs.append(
-                RequirerCSR(
+                RequirerRequest(
                     relation_id=relation.id,
                     certificate_signing_request=CertificateSigningRequest.from_string(
                         csr.certificate_signing_request
@@ -1272,11 +1273,11 @@ class TLSCertificatesRequiresV4(Object):
                 self._request_certificate(csr=csr, is_ca=certificate_request.is_ca)
 
     def get_assigned_certificate(
-        self, certificate_request: CertificateRequest
+        self, certificate_request: CertificateRequestAttributes
     ) -> Tuple[ProviderCertificate | None, PrivateKey | None]:
         """Get the certificate that was assigned to the given certificate request."""
         for requirer_csr in self.get_csrs_from_requirer_relation_data():
-            if certificate_request == CertificateRequest.from_csr(
+            if certificate_request == CertificateRequestAttributes.from_csr(
                 requirer_csr.certificate_signing_request,
                 requirer_csr.is_ca,
             ):
@@ -1292,7 +1293,7 @@ class TLSCertificatesRequiresV4(Object):
         return assigned_certificates, self.private_key
 
     def _find_certificate_in_relation_data(
-        self, csr: RequirerCSR
+        self, csr: RequirerRequest
     ) -> Optional[ProviderCertificate]:
         """Return the certificate that match the given CSR."""
         for provider_certificate in self.get_provider_certificates():
@@ -1504,10 +1505,10 @@ class TLSCertificatesProvidesV4(Object):
             else self.model.relations.get(self.relationship_name, [])
         )
 
-    def get_certificate_requests(self, relation_id: Optional[int] = None) -> List[RequirerCSR]:
+    def get_certificate_requests(self, relation_id: Optional[int] = None) -> List[RequirerRequest]:
         """Load certificate requests from the relation data."""
         relations = self._get_tls_relations(relation_id)
-        requirer_csrs: List[RequirerCSR] = []
+        requirer_csrs: List[RequirerRequest] = []
         for relation in relations:
             for unit in relation.units:
                 requirer_csrs.extend(self._load_requirer_databag(relation, unit))
@@ -1516,14 +1517,14 @@ class TLSCertificatesProvidesV4(Object):
 
     def _load_requirer_databag(
         self, relation: Relation, unit_or_app: Union[Application, Unit]
-    ) -> List[RequirerCSR]:
+    ) -> List[RequirerRequest]:
         try:
             requirer_relation_data = _RequirerData.load(relation.data[unit_or_app])
         except DataValidationError:
             logger.debug("Invalid requirer relation data for %s", unit_or_app.name)
             return []
         return [
-            RequirerCSR(
+            RequirerRequest(
                 relation_id=relation.id,
                 certificate_signing_request=CertificateSigningRequest.from_string(
                     csr.certificate_signing_request
@@ -1676,17 +1677,17 @@ class TLSCertificatesProvidesV4(Object):
 
     def get_outstanding_certificate_requests(
         self, relation_id: Optional[int] = None
-    ) -> List[RequirerCSR]:
+    ) -> List[RequirerRequest]:
         """Return CSR's for which no certificate has been issued.
 
         Args:
             relation_id (int): Relation id
 
         Returns:
-            list: List of RequirerCSR objects.
+            list: List of RequirerRequest objects.
         """
         requirer_csrs = self.get_certificate_requests(relation_id=relation_id)
-        outstanding_csrs: List[RequirerCSR] = []
+        outstanding_csrs: List[RequirerRequest] = []
         for relation_csr in requirer_csrs:
             if not self._certificate_issued_for_csr(
                 csr=relation_csr.certificate_signing_request,

--- a/tests/integration/v4/requirer_charm/src/charm.py
+++ b/tests/integration/v4/requirer_charm/src/charm.py
@@ -5,7 +5,7 @@
 from typing import FrozenSet, Optional, cast
 
 from charms.tls_certificates_interface.v4.tls_certificates import (
-    CertificateRequest,
+    CertificateRequestAttributes,
     Mode,
     TLSCertificatesRequiresV4,
 )
@@ -63,8 +63,8 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
         except KeyError:
             return False
 
-    def _get_certificate_request(self) -> CertificateRequest:
-        return CertificateRequest(
+    def _get_certificate_request(self) -> CertificateRequestAttributes:
+        return CertificateRequestAttributes(
             common_name=self._get_config_common_name(),
             sans_dns=self._get_config_sans_dns(),
             organization=self._get_config_organization_name(),

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
@@ -8,7 +8,7 @@ from ops.main import main
 
 from lib.charms.tls_certificates_interface.v4.tls_certificates import (
     CertificateAvailableEvent,
-    CertificateRequest,
+    CertificateRequestAttributes,
     Mode,
     TLSCertificatesRequiresV4,
 )
@@ -33,11 +33,11 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
         )
         self.framework.observe(self.on.get_certificate_action, self._on_get_certificate_action)
 
-    def _get_certificate_requests(self) -> List[CertificateRequest]:
+    def _get_certificate_requests(self) -> List[CertificateRequestAttributes]:
         if not self._get_config_common_name():
             return []
         return [
-            CertificateRequest(
+            CertificateRequestAttributes(
                 common_name=self._get_config_common_name(),
                 sans_dns=self._get_config_sans_dns(),
                 organization=self._get_config_organization_name(),

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
@@ -87,7 +87,7 @@ class TestTLSCertificatesRequiresV4:
 
         assert self.private_key_secret_exists(state_out.secrets)
 
-    @patch(LIB_DIR + ".CertificateRequest.generate_csr")
+    @patch(LIB_DIR + ".CertificateRequestAttributes.generate_csr")
     def test_given_certificate_requested_when_relation_joined_then_certificate_request_is_added_to_databag(  # noqa: E501
         self, patch_generate_csr
     ):
@@ -140,7 +140,7 @@ class TestTLSCertificatesRequiresV4:
             }
         )
 
-    @patch(LIB_DIR + ".CertificateRequest.generate_csr")
+    @patch(LIB_DIR + ".CertificateRequestAttributes.generate_csr")
     def test_given_ca_certificate_requested_when_relation_joined_then_certificate_request_is_added_to_databag(  # noqa: E501
         self, patch_generate_csr
     ):
@@ -415,7 +415,7 @@ class TestTLSCertificatesRequiresV4:
             }
         )
 
-    @patch(LIB_DIR + ".CertificateRequest.generate_csr")
+    @patch(LIB_DIR + ".CertificateRequestAttributes.generate_csr")
     def test_given_private_key_does_not_match_with_certificate_requests_when_relation_changed_then_certificate_request_is_replaced_in_databag(  # noqa: E501
         self, patch_generate_csr
     ):
@@ -484,7 +484,7 @@ class TestTLSCertificatesRequiresV4:
             }
         )
 
-    @patch(LIB_DIR + ".CertificateRequest.generate_csr")
+    @patch(LIB_DIR + ".CertificateRequestAttributes.generate_csr")
     def test_given_certificate_request_changed_when_relation_changed_then_new_certificate_is_requested(  # noqa: E501
         self, patch_generate_csr
     ):
@@ -849,7 +849,7 @@ class TestTLSCertificatesRequiresV4:
             "csr": csr,
         }
 
-    @patch(LIB_DIR + ".CertificateRequest.generate_csr")
+    @patch(LIB_DIR + ".CertificateRequestAttributes.generate_csr")
     def test_given_certificate_when_certificate_secret_expires_then_new_certificate_is_requested(  # noqa: E501
         self, patch_generate_csr
     ):


### PR DESCRIPTION
# Description

The aim of this PR is to make the code more readable by having names that are clearer in telling what does that specific object represent.

`CertificateRequest`: Although it represented a request from the requirer it didn't hold the actual csr pem string and it was easily confused with the `CertificateSigningRequest` object that does have the csr. We rename it to `CertificateRequestAttributes` which much closer to what it represents.

`RequirerCSR`: This a confusing name as it doesn't only contain the CSR, it represents a `CertificateSigningRequest` that is mapped to a relation id (to a specific requirer) and to an `is_ca` flag making it an object/request more general than a CSR.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
