### PR TITLE
fix: Fixes certificate secret management

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -318,7 +318,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 20
+LIBPATCH = 21
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1902,10 +1902,19 @@ class TLSCertificatesRequiresV3(Object):
                     )
                 else:
                     try:
+                        secret = self.model.get_secret(label=f"{LIBID}-{csr_in_sha256_hex}")
                         logger.debug(
                             "Setting secret with label %s", f"{LIBID}-{csr_in_sha256_hex}"
                         )
-                        secret = self.model.get_secret(label=f"{LIBID}-{csr_in_sha256_hex}")
+                        # Juju < 3.6 will create a new revision even if the content is the same
+                        if secret.get_content(
+                            refresh=True
+                        ).get("certificate", "") == certificate.certificate:
+                            logger.debug(
+                                "Secret %s with correct certificate already exists",
+                                f"{LIBID}-{csr_in_sha256_hex}",
+                            )
+                            return
                         secret.set_content(
                             {"certificate": certificate.certificate, "csr": certificate.csr}
                         )
@@ -1986,11 +1995,19 @@ class TLSCertificatesRequiresV3(Object):
         provider_certificate = self._find_certificate_in_relation_data(csr)
         if not provider_certificate:
             # A secret expired but we did not find matching certificate. Cleaning up
+            logger.warning(
+                "Failed to find matching certificate for csr, cleaning up secret %s",
+                event.secret.label,
+            )
             event.secret.remove_all_revisions()
             return
 
         if not provider_certificate.expiry_time:
             # A secret expired but matching certificate is invalid. Cleaning up
+            logger.warning(
+                "Certificate matching csr is invalid, cleaning up secret %s",
+                event.secret.label,
+            )
             event.secret.remove_all_revisions()
             return
 
@@ -2023,14 +2040,18 @@ class TLSCertificatesRequiresV3(Object):
             return provider_certificate
         return None
 
-    def _get_csr_from_secret(self, secret: Secret) -> str:
+    def _get_csr_from_secret(self, secret: Secret) -> str | None:
         """Extract the CSR from the secret label or content.
 
         This function is a workaround to maintain backwards compatibility
         and fix the issue reported in
         https://github.com/canonical/tls-certificates-interface/issues/228
         """
-        if not (csr := secret.get_content().get("csr", "")):
+        try:
+            content = secret.get_content(refresh=True)
+        except SecretNotFoundError:
+            return None
+        if not (csr := content.get("csr", None)):
             # In versions <14 of the Lib we were storing the CSR in the label of the secret
             # The CSR now is stored int the content of the secret, which was a breaking change
             # Here we get the CSR if the secret was created by an app using libpatch 14 or lower

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -1907,9 +1907,10 @@ class TLSCertificatesRequiresV3(Object):
                             "Setting secret with label %s", f"{LIBID}-{csr_in_sha256_hex}"
                         )
                         # Juju < 3.6 will create a new revision even if the content is the same
-                        if secret.get_content(
-                            refresh=True
-                        ).get("certificate", "") == certificate.certificate:
+                        if (
+                            secret.get_content(refresh=True).get("certificate", "")
+                            == certificate.certificate
+                        ):
                             logger.debug(
                                 "Secret %s with correct certificate already exists",
                                 f"{LIBID}-{csr_in_sha256_hex}",

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -1302,9 +1302,9 @@ class TLSCertificatesRequiresV4(Object):
                         secret = self.model.get_secret(label=secret_label)
                         logger.debug("Setting secret with label %s", secret_label)
                         # Juju < 3.6 will create a new revision even if the content is the same
-                        if secret.get_content(
-                            refresh=True
-                        ).get("certificate", "") == str(provider_certificate.certificate):
+                        if secret.get_content(refresh=True).get("certificate", "") == str(
+                            provider_certificate.certificate
+                        ):
                             logger.debug(
                                 "Secret %s with correct certificate already exists", secret_label
                             )

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -52,7 +52,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 PYDEPS = ["cryptography", "pydantic"]
 
@@ -1299,8 +1299,16 @@ class TLSCertificatesRequiresV4(Object):
                         logger.debug("Certificate requested for different attributes - Skipping")
                         continue
                     try:
-                        logger.debug("Setting secret with label %s", secret_label)
                         secret = self.model.get_secret(label=secret_label)
+                        logger.debug("Setting secret with label %s", secret_label)
+                        # Juju < 3.6 will create a new revision even if the content is the same
+                        if secret.get_content(
+                            refresh=True
+                        ).get("certificate", "") == str(provider_certificate.certificate):
+                            logger.debug(
+                                "Secret %s with correct certificate already exists", secret_label
+                            )
+                            return
                         secret.set_content(
                             content={
                                 "certificate": str(provider_certificate.certificate),


### PR DESCRIPTION
# Description

When a relation to a certificate provider is created:
- `relation-joined` runs
- The requirer sends its request (V3)
- `relation-changed` runs for the provider and the certificate is provided --> certificate secret is created
- `relation-changed` runs again and the secret is updated without an actual change of its content, but a new revision is created.
-  Time passes and `secret-expired` runs for both revisions, the code removes all revisions when the first event and it will fail to get the content of the secret when it handles the second one.
- `SecretNotFoundError` is raised

To fix the issue:
- New revision should not be created if secret content is not changed
- We should handle the possible `SecretNotFoundError` when running `get_content`

This PR:
- Fixes #228 
- Adds tests


## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
