### PR TITLE
feat: Removes old certificate secret revisions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,8 @@ on:
       - main
 
 concurrency:
-    group: ${{ github.ref == 'refs/heads/main' && format('ignore-main-{0}', github.run_id) || format('{0}-{1}', github.workflow, github.ref_name) }}
-    cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && format('ignore-main-{0}', github.run_id) || format('{0}-{1}', github.workflow, github.ref_name) }}
+  cancel-in-progress: true
 
 jobs:
   lint-report:
@@ -42,7 +42,7 @@ jobs:
         run: pip install tox
       - name: Run tests using tox
         run: tox -e unit
-  
+
   build:
     name: Build charm
     runs-on: ubuntu-22.04
@@ -56,7 +56,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-          channel: 5.0/stable
+          channel: 5.21/stable
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
       - name: Build charm

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -48,11 +48,11 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 LIBID = "afd8c2bccf834997afce12c2706d2ede"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 5
+LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["cryptography", "pydantic"]
 

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -32,7 +32,7 @@ from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
-from ops import BoundEvent, CharmBase, CharmEvents, SecretExpiredEvent
+from ops import BoundEvent, CharmBase, CharmEvents, SecretExpiredEvent, SecretRemoveEvent
 from ops.framework import EventBase, EventSource, Handle, Object
 from ops.jujuversion import JujuVersion
 from ops.model import (
@@ -48,7 +48,7 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 LIBID = "afd8c2bccf834997afce12c2706d2ede"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 4
+LIBAPI = 5
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
@@ -974,6 +974,7 @@ class TLSCertificatesRequiresV4(Object):
         self.framework.observe(charm.on[relationship_name].relation_created, self._configure)
         self.framework.observe(charm.on[relationship_name].relation_changed, self._configure)
         self.framework.observe(charm.on.secret_expired, self._on_secret_expired)
+        self.framework.observe(charm.on.secret_remove, self._on_secret_remove)
         for event in refresh_events:
             self.framework.observe(event, self._configure)
 
@@ -995,6 +996,10 @@ class TLSCertificatesRequiresV4(Object):
 
     def _mode_is_valid(self, mode) -> bool:
         return mode in [Mode.UNIT, Mode.APP]
+
+    def _on_secret_remove(self, event: SecretRemoveEvent) -> None:
+        """Handle Secret Removed Event."""
+        event.secret.remove_revision(event.revision)
 
     def _on_secret_expired(self, event: SecretExpiredEvent) -> None:
         """Handle Secret Expired Event.


### PR DESCRIPTION
# Description

When a new secret revision is created and all parties observing the secret refresh the revision they track to the latest one, juju will emit the SecretRemoveEvent to signal to the charm that the old revision can be removed.
We remove it to avoid the following scenario:
- The provider shares a new certificate before the expiry of the current one.
- The requirer creates a new secret revision where the new cert is stored.
- The current cert expires before the new one.
- The current cert expiry is triggered.
- The new certificate is removed because of the `remove_all_revisions` call when handling secret expiry.
- A new certificate is requested for no good reason.

Although it isn't that critical it should lead to a more predictable certificate life cycle.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
