### PR TITLE
chore: bump juju, lxd, and microk8s versions in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.6/stable
+          juju-channel: 3.4/stable
           provider: microk8s
           channel: 1.31-strict/stable
       - name: Run tests using tox
@@ -128,7 +128,7 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.6/stable
+          juju-channel: 3.4/stable
           provider: microk8s
           channel: 1.31-strict/stable
       - name: Run tests using tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-          channel: 5.0/stable
+          channel: 5.21/stable
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
       - name: Build charm
@@ -100,9 +100,9 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.4/stable
+          juju-channel: 3.6/stable
           provider: microk8s
-          channel: 1.29-strict/stable
+          channel: 1.31-strict/stable
       - name: Run tests using tox
         run: tox -e integration-v2-juju-3
       - name: Archive charmcraft logs
@@ -128,9 +128,9 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.4/stable
+          juju-channel: 3.6/stable
           provider: microk8s
-          channel: 1.28-strict/stable
+          channel: 1.31-strict/stable
       - name: Run tests using tox
         run: tox -e integration-v3
       - name: Archive charmcraft logs
@@ -156,9 +156,9 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.4/stable
+          juju-channel: 3.6/stable
           provider: microk8s
-          channel: 1.28-strict/stable
+          channel: 1.31-strict/stable
       - name: Run tests using tox
         run: tox -e integration-v4
       - name: Archive charmcraft logs


### PR DESCRIPTION
# Description

- Bump Juju to `3.6/stable`
- Bump lxd to `5.21/stable`
- Bump MicroK8s to `1.31-strict/stable`

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
