### PR TITLE
chore: add validation to ensure provided certificate matches private key

### DIFF
--- a/tests/integration/v4/requirer_charm/requirements.txt
+++ b/tests/integration/v4/requirer_charm/requirements.txt
@@ -14,7 +14,7 @@ ops==2.17.1
     # via -r requirements.in
 pycparser==2.22
     # via cffi
-pydantic==2.10.2
+pydantic==2.10.3
     # via -r requirements.in
 pydantic-core==2.27.1
     # via pydantic


### PR DESCRIPTION
# Description

On the Requirer side of this interface, when charms request to know their assigned certificates (ex. using the `get_assigned_certificates` method), any certificate provided through the relation would be returned, even if that certificate does not match the requirer's private key. In order to ensure that bad certificates (ex. if the TLS provider gets corrupted) don't make their way into the TLS requirer workload, here we add a validation to ensure that the provided certificate matches with the requirer's private key. 

This security improvement came in as a request from the data platform team.

Fixes #283 

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
