### PR TITLE
chore: use typing.Union in lib v4 instead of |

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -1105,7 +1105,7 @@ class TLSCertificatesRequiresV4(Object):
         raise TLSCertificatesError("Invalid mode")
 
     @property
-    def private_key(self) -> PrivateKey | None:
+    def private_key(self) -> Union[PrivateKey, None]:
         """Return the private key."""
         if not self._private_key_generated():
             return None
@@ -1274,7 +1274,7 @@ class TLSCertificatesRequiresV4(Object):
 
     def get_assigned_certificate(
         self, certificate_request: CertificateRequestAttributes
-    ) -> Tuple[ProviderCertificate | None, PrivateKey | None]:
+    ) -> Tuple[Union[ProviderCertificate, None], Union[PrivateKey, None]]:
         """Get the certificate that was assigned to the given certificate request."""
         for requirer_csr in self.get_csrs_from_requirer_relation_data():
             if certificate_request == CertificateRequestAttributes.from_csr(
@@ -1284,7 +1284,9 @@ class TLSCertificatesRequiresV4(Object):
                 return self._find_certificate_in_relation_data(requirer_csr), self.private_key
         return None, None
 
-    def get_assigned_certificates(self) -> Tuple[List[ProviderCertificate], PrivateKey | None]:
+    def get_assigned_certificates(
+        self,
+    ) -> Tuple[List[ProviderCertificate], Union[PrivateKey, None]]:
         """Get a list of certificates that were assigned to this or app."""
         assigned_certificates = []
         for requirer_csr in self.get_csrs_from_requirer_relation_data():


### PR DESCRIPTION
# Description

Here we replace the `|` operand with Union, allowing the lib to work on charms built on Ubuntu 20.04.

A similar PR was created earlier for v3: #263 

## Context

I was trying to use the TLS library v4 in the Istio Pilot charm, but it is built for Ubuntu 20.04 (ref [here](https://github.com/canonical/istio-operators/blob/main/charms/istio-pilot/charmcraft.yaml)) which comes with Python 3.8.x. The `|` operand was introduced in Python 3.9.

## Logs

```
unit-istio-pilot-0: 13:00:34 WARNING unit.istio-pilot/0.install Traceback (most recent call last):
unit-istio-pilot-0: 13:00:34 WARNING unit.istio-pilot/0.install   File "./src/charm.py", line 20, in <module>
unit-istio-pilot-0: 13:00:34 WARNING unit.istio-pilot/0.install     from charms.tls_certificates_interface.v4.tls_certificates import TLSCertificatesRequiresV4, Mode, CertificateRequestAttributes
unit-istio-pilot-0: 13:00:34 WARNING unit.istio-pilot/0.install   File "/var/lib/juju/agents/unit-istio-pilot-0/charm/lib/charms/tls_certificates_interface/v4/tls_certificates.py", line 938, in <module>
unit-istio-pilot-0: 13:00:34 WARNING unit.istio-pilot/0.install     class TLSCertificatesRequiresV4(Object):
unit-istio-pilot-0: 13:00:34 WARNING unit.istio-pilot/0.install   File "/var/lib/juju/agents/unit-istio-pilot-0/charm/lib/charms/tls_certificates_interface/v4/tls_certificates.py", line 1077, in TLSCertificatesRequiresV4
unit-istio-pilot-0: 13:00:34 WARNING unit.istio-pilot/0.install     def private_key(self) -> PrivateKey | None:
unit-istio-pilot-0: 13:00:34 WARNING unit.istio-pilot/0.install TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```
## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
