### PR TITLE
chore: use python 3.8 for static checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,4 @@ skip = "build,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
 [tool.pyright]
 include = ["src/**", "lib/**"]
+pythonVersion = "3.8"


### PR DESCRIPTION
# Description

Here we use python 3.8 for static checks. Check failures will mean that our library code is not compatible with Python 3.8. 

## Rationale

This ensures that our lib keeps on being usable on charms built on Ubuntu 20.04. Without this check, it is easy to introduce new syntax without realizing that we're breaking 20.04 charms (ex. with the `|` character in return types). 

## Logs

Check failures will look like:

```
(venv) guillaume@courge:~/code/tls-certificates-interface$ tox -e static
static: commands[0]> pyright /home/guillaume/code/tls-certificates-interface/src/ /home/guillaume/code/tls-certificates-interface/tests/unit/ /home/guillaume/code/tls-certificates-interface/tests/integration/ /home/guillaume/code/tls-certificates-interface/lib/
/home/guillaume/code/tls-certificates-interface/lib/charms/tls_certificates_interface/v4/tls_certificates.py
  /home/guillaume/code/tls-certificates-interface/lib/charms/tls_certificates_interface/v4/tls_certificates.py:1108:41 - error: Alternative syntax for unions requires Python 3.10 or newer (reportGeneralTypeIssues)
1 error, 0 warnings, 0 informations 
static: exit 1 (2.08 seconds) /home/guillaume/code/tls-certificates-interface> pyright /home/guillaume/code/tls-certificates-interface/src/ /home/guillaume/code/tls-certificates-interface/tests/unit/ /home/guillaume/code/tls-certificates-interface/tests/integration/ /home/guillaume/code/tls-certificates-interface/lib/ pid=3533040
  static: FAIL code 1 (2.10=setup[0.02]+cmd[2.08] seconds)
  evaluation failed :( (2.12 seconds)
```
## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
