### PR TITLE
build: Enable pyright to check if type hints are missing

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -307,7 +307,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 28
+LIBPATCH = 29
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -459,7 +459,7 @@ class CertificateAvailableEvent(EventBase):
 class CertificateExpiringEvent(EventBase):
     """Charm Event triggered when a TLS certificate is almost expired."""
 
-    def __init__(self, handle, certificate: str, expiry: str):
+    def __init__(self, handle: Handle, certificate: str, expiry: str):
         """CertificateExpiringEvent.
 
         Args:

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -318,7 +318,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 23
+LIBPATCH = 24
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -526,7 +526,7 @@ class CertificateAvailableEvent(EventBase):
 class CertificateExpiringEvent(EventBase):
     """Charm Event triggered when a TLS certificate is almost expired."""
 
-    def __init__(self, handle, certificate: str, expiry: str):
+    def __init__(self, handle: Handle, certificate: str, expiry: str):
         """CertificateExpiringEvent.
 
         Args:

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -52,7 +52,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 PYDEPS = ["cryptography", "pydantic"]
 
@@ -1025,7 +1025,7 @@ class TLSCertificatesRequiresV4(Object):
         self._find_available_certificates()
         self._cleanup_certificate_requests()
 
-    def _mode_is_valid(self, mode) -> bool:
+    def _mode_is_valid(self, mode: Mode) -> bool:
         return mode in [Mode.UNIT, Mode.APP]
 
     def _on_secret_remove(self, event: SecretRemoveEvent) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,4 @@ skip = "build,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 [tool.pyright]
 include = ["src/**", "lib/**"]
 pythonVersion = "3.8"
+reportMissingParameterType = true

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,6 +4,9 @@
 
 """Placeholder charm."""
 
+from typing import Any
+
+from ops import EventBase
 from ops.charm import CharmBase
 from ops.main import main
 
@@ -11,11 +14,11 @@ from ops.main import main
 class PlaceholderCharm(CharmBase):
     """Placeholder charm."""
 
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.framework.observe(self.on.install, self._on_install)
 
-    def _on_install(self, event):
+    def _on_install(self, event: EventBase):
         pass
 
 

--- a/tests/integration/v2/provider_charm/src/charm.py
+++ b/tests/integration/v2/provider_charm/src/charm.py
@@ -3,7 +3,7 @@
 # See LICENSE file for licensing details.
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from charms.tls_certificates_interface.v2.tls_certificates import (
     CertificateCreationRequestEvent,
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 class DummyTLSCertificatesProviderCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificates = TLSCertificatesProvidesV2(self, "certificates")
         self.framework.observe(self.on.install, self._on_install)

--- a/tests/integration/v2/requirer_charm/src/charm.py
+++ b/tests/integration/v2/requirer_charm/src/charm.py
@@ -4,7 +4,7 @@
 
 import json
 import logging
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from charms.tls_certificates_interface.v2.tls_certificates import (
     CertificateAvailableEvent,
@@ -14,6 +14,7 @@ from charms.tls_certificates_interface.v2.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
+from ops import EventBase
 from ops.charm import ActionEvent, CharmBase, InstallEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
@@ -25,7 +26,7 @@ CONFIG_CHANGED = "banana"
 
 
 class DummyTLSCertificatesRequirerCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificates = TLSCertificatesRequiresV2(
             self,
@@ -151,7 +152,7 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
         self._generate_private_key()
         self.unit.status = BlockedStatus("Waiting for relation to be created")
 
-    def _on_certificates_relation_joined(self, event) -> None:
+    def _on_certificates_relation_joined(self, event: EventBase) -> None:
         self._request_certificate()
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:

--- a/tests/integration/v2/test_integration_v2.py
+++ b/tests/integration/v2/test_integration_v2.py
@@ -5,6 +5,8 @@
 import logging
 import shutil
 
+from pytest_operator.plugin import OpsTest
+
 logger = logging.getLogger(__name__)
 
 LIB_DIR = "lib/charms/tls_certificates_interface/v2/tls_certificates.py"
@@ -23,7 +25,10 @@ class TestIntegration:
     requirer_charm = None
     provider_charm = None
 
-    async def test_given_charms_packed_when_deploy_charm_then_status_is_blocked(self, ops_test):
+    async def test_given_charms_packed_when_deploy_charm_then_status_is_blocked(
+        self, ops_test: OpsTest
+    ):
+        assert ops_test.model
         copy_lib_content()
         TestIntegration.requirer_charm = await ops_test.build_charm(f"{REQUIRER_CHARM_DIR}/")
         TestIntegration.provider_charm = await ops_test.build_charm(f"{PROVIDER_CHARM_DIR}/")
@@ -44,7 +49,10 @@ class TestIntegration:
             timeout=1000,
         )
 
-    async def test_given_charms_deployed_when_relate_then_status_is_active(self, ops_test):
+    async def test_given_charms_deployed_when_relate_then_status_is_active(
+        self, ops_test: OpsTest
+    ):
+        assert ops_test.model
         await ops_test.model.add_relation(
             relation1=TLS_CERTIFICATES_REQUIRER_APP_NAME,
             relation2=TLS_CERTIFICATES_PROVIDER_APP_NAME,
@@ -56,8 +64,12 @@ class TestIntegration:
             timeout=1000,
         )
 
-    async def test_given_charms_deployed_when_relate_then_requirer_received_certs(self, ops_test):
+    async def test_given_charms_deployed_when_relate_then_requirer_received_certs(
+        self, ops_test: OpsTest
+    ):
+        assert ops_test.model
         requirer_unit = ops_test.model.units[f"{TLS_CERTIFICATES_REQUIRER_APP_NAME}/0"]
+        assert requirer_unit
 
         action = await requirer_unit.run_action(action_name="get-certificate")
 
@@ -69,8 +81,9 @@ class TestIntegration:
         assert "chain" in action_output and action_output["chain"] is not None
 
     async def test_given_additional_requirer_charm_deployed_when_relate_then_requirer_received_certs(  # noqa: E501
-        self, ops_test
+        self, ops_test: OpsTest
     ):
+        assert ops_test.model
         new_requirer_app_name = "new-tls-requirer"
         await ops_test.model.deploy(
             TestIntegration.requirer_charm, application_name=new_requirer_app_name, series="jammy"
@@ -88,6 +101,7 @@ class TestIntegration:
             timeout=1000,
         )
         requirer_unit = ops_test.model.units[f"{new_requirer_app_name}/0"]
+        assert requirer_unit
 
         action = await requirer_unit.run_action(action_name="get-certificate")
 
@@ -98,7 +112,8 @@ class TestIntegration:
         assert "certificate" in action_output and action_output["certificate"] is not None
         assert "chain" in action_output and action_output["chain"] is not None
 
-    async def test_given_enough_time_passed_then_certificate_expired(self, ops_test):  # noqa: E501
+    async def test_given_enough_time_passed_then_certificate_expired(self, ops_test: OpsTest):  # noqa: E501
+        assert ops_test.model
         await ops_test.model.wait_for_idle(
             apps=[
                 TLS_CERTIFICATES_REQUIRER_APP_NAME,
@@ -107,5 +122,6 @@ class TestIntegration:
             timeout=1000,
         )
         requirer_unit = ops_test.model.units[f"{TLS_CERTIFICATES_REQUIRER_APP_NAME}/0"]
+        assert requirer_unit
 
         assert requirer_unit.workload_status_message == "Told you, now your certificate expired"

--- a/tests/integration/v3/provider_charm/src/charm.py
+++ b/tests/integration/v3/provider_charm/src/charm.py
@@ -3,7 +3,7 @@
 # See LICENSE file for licensing details.
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateCreationRequestEvent,
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 class DummyTLSCertificatesProviderCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificates = TLSCertificatesProvidesV3(self, "certificates")
         self.framework.observe(self.on.install, self._on_install)

--- a/tests/integration/v3/requirer_charm/src/charm.py
+++ b/tests/integration/v3/requirer_charm/src/charm.py
@@ -4,7 +4,7 @@
 
 import json
 import logging
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateAvailableEvent,
@@ -14,6 +14,7 @@ from charms.tls_certificates_interface.v3.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
+from ops import EventBase
 from ops.charm import ActionEvent, CharmBase, InstallEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
@@ -25,7 +26,7 @@ CONFIG_CHANGED = "banana"
 
 
 class DummyTLSCertificatesRequirerCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificates = TLSCertificatesRequiresV3(
             self,
@@ -151,7 +152,7 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
         self._generate_private_key()
         self.unit.status = BlockedStatus("Waiting for relation to be created")
 
-    def _on_certificates_relation_created(self, event) -> None:
+    def _on_certificates_relation_created(self, event: EventBase) -> None:
         self._request_certificate()
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:

--- a/tests/integration/v3/test_integration_v3.py
+++ b/tests/integration/v3/test_integration_v3.py
@@ -5,6 +5,8 @@
 import logging
 import shutil
 
+from pytest_operator.plugin import OpsTest
+
 logger = logging.getLogger(__name__)
 
 LIB_DIR = "lib/charms/tls_certificates_interface/v3/tls_certificates.py"
@@ -23,7 +25,10 @@ class TestIntegration:
     requirer_charm = None
     provider_charm = None
 
-    async def test_given_charms_packed_when_deploy_charm_then_status_is_blocked(self, ops_test):
+    async def test_given_charms_packed_when_deploy_charm_then_status_is_blocked(
+        self, ops_test: OpsTest
+    ):
+        assert ops_test.model
         copy_lib_content()
         TestIntegration.requirer_charm = await ops_test.build_charm(f"{REQUIRER_CHARM_DIR}/")
         TestIntegration.provider_charm = await ops_test.build_charm(f"{PROVIDER_CHARM_DIR}/")
@@ -44,7 +49,10 @@ class TestIntegration:
             timeout=1000,
         )
 
-    async def test_given_charms_deployed_when_relate_then_status_is_active(self, ops_test):
+    async def test_given_charms_deployed_when_relate_then_status_is_active(
+        self, ops_test: OpsTest
+    ):
+        assert ops_test.model
         await ops_test.model.add_relation(
             relation1=TLS_CERTIFICATES_REQUIRER_APP_NAME,
             relation2=TLS_CERTIFICATES_PROVIDER_APP_NAME,
@@ -56,8 +64,12 @@ class TestIntegration:
             timeout=1000,
         )
 
-    async def test_given_charms_deployed_when_relate_then_requirer_received_certs(self, ops_test):
+    async def test_given_charms_deployed_when_relate_then_requirer_received_certs(
+        self, ops_test: OpsTest
+    ):
+        assert ops_test.model
         requirer_unit = ops_test.model.units[f"{TLS_CERTIFICATES_REQUIRER_APP_NAME}/0"]
+        assert requirer_unit
 
         action = await requirer_unit.run_action(action_name="get-certificate")
 
@@ -70,8 +82,9 @@ class TestIntegration:
         assert "chain" in action_output and action_output["chain"] is not None
 
     async def test_given_additional_requirer_charm_deployed_when_relate_then_requirer_received_certs(  # noqa: E501
-        self, ops_test
+        self, ops_test: OpsTest
     ):
+        assert ops_test.model
         new_requirer_app_name = "new-tls-requirer"
         await ops_test.model.deploy(
             TestIntegration.requirer_charm, application_name=new_requirer_app_name, series="jammy"
@@ -89,6 +102,7 @@ class TestIntegration:
             timeout=1000,
         )
         requirer_unit = ops_test.model.units[f"{new_requirer_app_name}/0"]
+        assert requirer_unit
 
         action = await requirer_unit.run_action(action_name="get-certificate")
 
@@ -100,7 +114,8 @@ class TestIntegration:
         assert "certificate" in action_output and action_output["certificate"] is not None
         assert "chain" in action_output and action_output["chain"] is not None
 
-    async def test_given_enough_time_passed_then_certificate_expired(self, ops_test):  # noqa: E501
+    async def test_given_enough_time_passed_then_certificate_expired(self, ops_test: OpsTest):  # noqa: E501
+        assert ops_test.model
         await ops_test.model.wait_for_idle(
             apps=[
                 TLS_CERTIFICATES_REQUIRER_APP_NAME,
@@ -109,5 +124,6 @@ class TestIntegration:
             timeout=1000,
         )
         requirer_unit = ops_test.model.units[f"{TLS_CERTIFICATES_REQUIRER_APP_NAME}/0"]
+        assert requirer_unit
 
         assert requirer_unit.workload_status_message == "Told you, now your certificate expired"

--- a/tests/integration/v4/provider_charm/src/charm.py
+++ b/tests/integration/v4/provider_charm/src/charm.py
@@ -3,13 +3,14 @@
 # See LICENSE file for licensing details.
 
 import logging
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from charms.tls_certificates_interface.v4.tls_certificates import (
     Certificate,
     ProviderCertificate,
     TLSCertificatesProvidesV4,
 )
+from ops import EventBase
 from ops.charm import CharmBase, CollectStatusEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, SecretNotFoundError, WaitingStatus
@@ -26,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class DummyTLSCertificatesProviderCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificates = TLSCertificatesProvidesV4(self, "certificates")
         self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
@@ -47,7 +48,7 @@ class DummyTLSCertificatesProviderCharm(CharmBase):
             return
         event.add_status(ActiveStatus())
 
-    def _configure(self, event) -> None:
+    def _configure(self, event: EventBase) -> None:
         if not self.unit.is_leader():
             logger.info("Not a leader")
             return

--- a/tests/integration/v4/requirer_charm/src/charm.py
+++ b/tests/integration/v4/requirer_charm/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from typing import FrozenSet, Optional, cast
+from typing import Any, FrozenSet, Optional, cast
 
 from charms.tls_certificates_interface.v4.tls_certificates import (
     CertificateRequestAttributes,
@@ -15,7 +15,7 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 
 class DummyTLSCertificatesRequirerCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         certificate_request = self._get_certificate_request()
         self.certificates = TLSCertificatesRequiresV4(

--- a/tests/integration/v4/test_integration_v4.py
+++ b/tests/integration/v4/test_integration_v4.py
@@ -7,6 +7,7 @@ import shutil
 import time
 
 from certificates import Certificate
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,10 @@ class TestIntegration:
     requirer_charm = None
     provider_charm = None
 
-    async def test_given_charms_packed_when_deploy_charm_then_status_is_blocked(self, ops_test):
+    async def test_given_charms_packed_when_deploy_charm_then_status_is_blocked(
+        self, ops_test: OpsTest
+    ):
+        assert ops_test.model
         copy_lib_content()
         TestIntegration.requirer_charm = await ops_test.build_charm(f"{REQUIRER_CHARM_DIR}/")
         TestIntegration.provider_charm = await ops_test.build_charm(f"{PROVIDER_CHARM_DIR}/")
@@ -47,7 +51,10 @@ class TestIntegration:
             timeout=1000,
         )
 
-    async def test_given_charms_deployed_when_relate_then_status_is_active(self, ops_test):
+    async def test_given_charms_deployed_when_relate_then_status_is_active(
+        self, ops_test: OpsTest
+    ):
+        assert ops_test.model
         await ops_test.model.add_relation(
             relation1=TLS_CERTIFICATES_REQUIRER_APP_NAME,
             relation2=TLS_CERTIFICATES_PROVIDER_APP_NAME,
@@ -59,8 +66,12 @@ class TestIntegration:
             timeout=1000,
         )
 
-    async def test_given_charms_deployed_when_relate_then_requirer_received_certs(self, ops_test):
+    async def test_given_charms_deployed_when_relate_then_requirer_received_certs(
+        self, ops_test: OpsTest
+    ):
+        assert ops_test.model
         requirer_unit = ops_test.model.units[f"{TLS_CERTIFICATES_REQUIRER_APP_NAME}/0"]
+        assert requirer_unit
 
         action = await requirer_unit.run_action(action_name="get-certificate")
 
@@ -73,8 +84,9 @@ class TestIntegration:
         assert "chain" in action_output and action_output["chain"] is not None
 
     async def test_given_additional_requirer_charm_deployed_when_relate_then_requirer_received_certs(  # noqa: E501
-        self, ops_test
+        self, ops_test: OpsTest
     ):
+        assert ops_test.model
         new_requirer_app_name = "new-tls-requirer"
         await ops_test.model.deploy(
             TestIntegration.requirer_charm, application_name=new_requirer_app_name, series="jammy"
@@ -92,6 +104,7 @@ class TestIntegration:
             timeout=1000,
         )
         requirer_unit = ops_test.model.units[f"{new_requirer_app_name}/0"]
+        assert requirer_unit
 
         action = await requirer_unit.run_action(action_name="get-certificate")
 
@@ -104,9 +117,11 @@ class TestIntegration:
         assert "chain" in action_output and action_output["chain"] is not None
 
     async def test_given_4_min_certificate_validity_when_certificate_expires_then_certificate_is_automatically_renewed(  # noqa: E501
-        self, ops_test
+        self, ops_test: OpsTest
     ):
+        assert ops_test.model
         requirer_unit = ops_test.model.units[f"{TLS_CERTIFICATES_REQUIRER_APP_NAME}/0"]
+        assert requirer_unit
 
         action = await requirer_unit.run_action(action_name="get-certificate")
 

--- a/tests/unit/charms/tls_certificates_interface/v2/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/dummy_provider_charm/src/charm.py
@@ -1,6 +1,8 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from typing import Any
+
 from ops.charm import CharmBase
 from ops.main import main
 
@@ -12,7 +14,7 @@ from lib.charms.tls_certificates_interface.v2.tls_certificates import (
 
 
 class DummyTLSCertificatesProviderCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificates = TLSCertificatesProvidesV2(self, "certificates")
         self.framework.observe(

--- a/tests/unit/charms/tls_certificates_interface/v2/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/dummy_requirer_charm/src/charm.py
@@ -1,6 +1,8 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from typing import Any
+
 from ops.charm import CharmBase
 from ops.main import main
 
@@ -14,7 +16,7 @@ from lib.charms.tls_certificates_interface.v2.tls_certificates import (
 
 
 class DummyTLSCertificatesRequirerCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificates = TLSCertificatesRequiresV2(
             self, "certificates", expiry_notification_time=168

--- a/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v2/test_tls_certificates_v2_provides.py
@@ -5,7 +5,7 @@
 import json
 import unittest
 from typing import Mapping
-from unittest.mock import PropertyMock, call, patch
+from unittest.mock import MagicMock, PropertyMock, call, patch
 
 from ops import testing
 
@@ -95,7 +95,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         new_callable=PropertyMock,
     )
     def test_given_csr_in_relation_data_when_relation_changed_then_certificate_creation_request_is_emitted(  # noqa: E501
-        self, patch_certificate_creation_request
+        self, mock_certificate_creation_request: MagicMock
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
         self.harness.set_leader(is_leader=True)
@@ -113,7 +113,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             relation_id=relation_id, app_or_unit=self.remote_unit_name, key_values=key_values
         )
 
-        patch_certificate_creation_request.assert_has_calls(
+        mock_certificate_creation_request.assert_has_calls(
             [call().emit(certificate_signing_request=csr, relation_id=relation_id, is_ca=False)]
         )
 
@@ -122,7 +122,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         new_callable=PropertyMock,
     )
     def test_given_no_csr_in_certificate_signing_request_when_relation_changed_then_certificate_creation_request_is_not_emitted(  # noqa: E501
-        self, patch_certificate_creation_request
+        self, mock_certificate_creation_request: MagicMock
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
         key_values = {
@@ -138,14 +138,14 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             relation_id=relation_id, app_or_unit=self.remote_unit_name, key_values=key_values
         )
 
-        patch_certificate_creation_request.assert_not_called()
+        mock_certificate_creation_request.assert_not_called()
 
     @patch(
         f"{LIB_DIR}.CertificatesProviderCharmEvents.certificate_creation_request",
         new_callable=PropertyMock,
     )
     def test_given_certificate_for_csr_already_in_relation_data_when_on_relation_changed_then_certificate_creation_request_is_not_emitted(  # noqa: E501
-        self, patch_certificate_creation_request
+        self, mock_certificate_creation_request: MagicMock
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
         self.harness.set_leader(is_leader=True)
@@ -183,14 +183,14 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             key_values=requirer_unit_data,
         )
 
-        patch_certificate_creation_request.assert_not_called()
+        mock_certificate_creation_request.assert_not_called()
 
     @patch(
         f"{LIB_DIR}.CertificatesProviderCharmEvents.certificate_creation_request",
         new_callable=PropertyMock,
     )
     def test_given_unit_not_leader_when_relation_changed_then_certificate_creation_request_is_not_emitted(  # noqa: E501
-        self, patch_certificate_creation_request
+        self, mock_certificate_creation_request: MagicMock
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
         csr = "whatever csr"
@@ -210,14 +210,14 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             key_values=requirer_unit_data,
         )
 
-        patch_certificate_creation_request.assert_not_called()
+        mock_certificate_creation_request.assert_not_called()
 
     @patch(f"{LIB_DIR}.TLSCertificatesProvidesV2.remove_certificate")
     @patch(
         f"{LIB_DIR}.CertificatesProviderCharmEvents.certificate_revocation_request",
     )
     def test_given_unit_not_leader_when_relation_changed_then_certificate_revocation_request_is_not_emitted(  # noqa: E501
-        self, patch_certificate_revocation_request, _
+        self, mock_certificate_revocation_request: MagicMock, _
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
         remote_unit_relation_data = {"certificate_signing_requests": "[]"}
@@ -228,14 +228,14 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             key_values=remote_unit_relation_data,
         )
 
-        patch_certificate_revocation_request.emit.assert_not_called()
+        mock_certificate_revocation_request.emit.assert_not_called()
 
     @patch(f"{LIB_DIR}.TLSCertificatesProvidesV2.remove_certificate")
     @patch(
         f"{LIB_DIR}.CertificatesProviderCharmEvents.certificate_revocation_request",
     )
     def test_given_csr_in_provider_relation_data_but_not_in_requirer_when_on_relation_changed_then_certificate_revocation_request_is_emitted(  # noqa: E501
-        self, patch_certificate_revocation_request, _
+        self, mock_certificate_revocation_request: MagicMock, _
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
         self.harness.set_leader(is_leader=True)
@@ -267,7 +267,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             key_values=remote_unit_relation_data,
         )
 
-        patch_certificate_revocation_request.emit.assert_called_with(
+        mock_certificate_revocation_request.emit.assert_called_with(
             certificate=certificate,
             certificate_signing_request=csr,
             ca=ca,
@@ -282,7 +282,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
     def test_given_csr_in_provider_relation_data_but_not_in_requirer_when_on_relation_changed_then_remove_certificate_is_called(  # noqa: E501
         self,
         _,
-        patch_remove_certificate,
+        mock_remove_certificate: MagicMock,
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
         self.harness.set_leader(is_leader=True)
@@ -310,7 +310,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             key_values=remote_unit_relation_data,
         )
 
-        patch_remove_certificate.assert_called_with(certificate=certificate)
+        mock_remove_certificate.assert_called_with(certificate=certificate)
 
     @patch(f"{LIB_DIR}.TLSCertificatesProvidesV2.remove_certificate")
     @patch(
@@ -320,7 +320,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
     def test_given_unit_not_leader_when_relation_changed_then_remove_certificate_is_not_called(
         self,
         _,
-        patch_remove_certificate,
+        mock_remove_certificate: MagicMock,
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
         self.harness.set_leader(is_leader=True)
@@ -332,7 +332,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             key_values=remote_unit_relation_data,
         )
 
-        patch_remove_certificate.assert_not_called()
+        mock_remove_certificate.assert_not_called()
 
     def test_given_no_data_in_relation_data_when_set_relation_certificate_then_certificate_is_added_to_relation_data(  # noqa: E501
         self,
@@ -719,7 +719,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
 
     @patch(f"{BASE_CHARM_DIR}._on_certificate_creation_request")
     def test_given_more_than_one_application_related_to_operator_when_csrs_are_added_to_remote_units_databag_then_certificate_creation_requests_are_triggered(  # noqa: E501
-        self, patch_certificate_creation_request
+        self, mock_certificate_creation_request: MagicMock
     ):
         remote_app_1 = "tls-requirer-1"
         remote_app_2 = "tls-requirer-2"
@@ -769,7 +769,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             key_values=requirer_app_2_unit_data,
         )
 
-        call_args_list = patch_certificate_creation_request.call_args_list
+        call_args_list = mock_certificate_creation_request.call_args_list
         self.assertEqual(call_args_list[0].args[0].certificate_signing_request, csr_1)
         self.assertEqual(call_args_list[0].args[0].relation_id, relation_1_id)
         self.assertEqual(call_args_list[1].args[0].certificate_signing_request, csr_2)
@@ -780,7 +780,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
         new_callable=PropertyMock,
     )
     def test_given_requirer_unit_requests_ca_when_relation_changed_then_certificate_creation_request_is_emitted(  # noqa: E501
-        self, patch_certificate_creation_request
+        self, mock_certificate_creation_request: MagicMock
     ):
         relation_id = self.create_certificates_relation_with_1_remote_unit()
         self.harness.set_leader(is_leader=True)
@@ -801,7 +801,7 @@ class TestTLSCertificatesProvides(unittest.TestCase):
             key_values=remote_unit_relation_data,
         )
 
-        patch_certificate_creation_request.assert_has_calls(
+        mock_certificate_creation_request.assert_has_calls(
             [
                 call().emit(
                     certificate_signing_request=csr,

--- a/tests/unit/charms/tls_certificates_interface/v3/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/dummy_provider_charm/src/charm.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from typing import Any
+
 from ops.charm import CharmBase
 from ops.main import main
 
@@ -12,7 +14,7 @@ from lib.charms.tls_certificates_interface.v3.tls_certificates import (
 
 
 class DummyTLSCertificatesProviderCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificates = TLSCertificatesProvidesV3(self, "certificates")
         self.framework.observe(

--- a/tests/unit/charms/tls_certificates_interface/v3/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v3/dummy_requirer_charm/src/charm.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from typing import Any
+
 from ops.charm import CharmBase
 from ops.main import main
 
@@ -14,7 +16,7 @@ from lib.charms.tls_certificates_interface.v3.tls_certificates import (
 
 
 class DummyTLSCertificatesRequirerCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificates = TLSCertificatesRequiresV3(
             self, "certificates", expiry_notification_time=168

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_provider_charm/src/charm.py
@@ -3,7 +3,7 @@
 
 import base64
 import re
-from typing import List
+from typing import Any, List
 
 from ops.charm import ActionEvent, CharmBase
 from ops.framework import EventBase
@@ -43,7 +43,7 @@ def parse_ca_chain(ca_chain_pem: str) -> List[str]:
 
 
 class DummyTLSCertificatesProviderCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificates = TLSCertificatesProvidesV4(self, "certificates")
         self.framework.observe(self.on.update_status, self._configure)

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from typing import FrozenSet, List, Optional, cast
+from typing import Any, FrozenSet, List, Optional, cast
 
 from ops.charm import ActionEvent, CharmBase
 from ops.main import main
@@ -15,7 +15,7 @@ from lib.charms.tls_certificates_interface.v4.tls_certificates import (
 
 
 class DummyTLSCertificatesRequirerCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         certificate_requests = self._get_certificate_requests()
         self.certificates = TLSCertificatesRequiresV4(

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
@@ -5,7 +5,7 @@ import datetime
 import json
 from pathlib import Path
 from typing import Iterable
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import ops
 import pytest
@@ -90,14 +90,14 @@ class TestTLSCertificatesRequiresV4:
 
     @patch(LIB_DIR + ".CertificateRequestAttributes.generate_csr")
     def test_given_certificate_requested_when_relation_joined_then_certificate_request_is_added_to_databag(  # noqa: E501
-        self, patch_generate_csr
+        self, mock_generate_csr: MagicMock
     ):
         private_key = generate_private_key()
         csr = generate_csr(
             private_key=private_key,
             common_name="example.com",
         )
-        patch_generate_csr.return_value = csr
+        mock_generate_csr.return_value = csr
         certificates_relation = scenario.Relation(
             endpoint="certificates",
             interface="tls-certificates",
@@ -143,14 +143,14 @@ class TestTLSCertificatesRequiresV4:
 
     @patch(LIB_DIR + ".CertificateRequestAttributes.generate_csr")
     def test_given_ca_certificate_requested_when_relation_joined_then_certificate_request_is_added_to_databag(  # noqa: E501
-        self, patch_generate_csr
+        self, mock_generate_csr: MagicMock
     ):
         private_key = generate_private_key()
         csr = generate_csr(
             private_key=private_key,
             common_name="example.com",
         )
-        patch_generate_csr.return_value = csr
+        mock_generate_csr.return_value = csr
         certificates_relation = scenario.Relation(
             endpoint="certificates",
             interface="tls-certificates",
@@ -418,7 +418,7 @@ class TestTLSCertificatesRequiresV4:
 
     @patch(LIB_DIR + ".CertificateRequestAttributes.generate_csr")
     def test_given_private_key_does_not_match_with_certificate_requests_when_relation_changed_then_certificate_request_is_replaced_in_databag(  # noqa: E501
-        self, patch_generate_csr
+        self, mock_generate_csr: MagicMock
     ):
         initial_private_key = generate_private_key()
         csr = generate_csr(
@@ -448,7 +448,7 @@ class TestTLSCertificatesRequiresV4:
             private_key=new_private_key,
             common_name="example.com",
         )
-        patch_generate_csr.return_value = new_csr
+        mock_generate_csr.return_value = new_csr
 
         state_in = scenario.State(
             relations={certificates_relation},
@@ -487,7 +487,7 @@ class TestTLSCertificatesRequiresV4:
 
     @patch(LIB_DIR + ".CertificateRequestAttributes.generate_csr")
     def test_given_certificate_request_changed_when_relation_changed_then_new_certificate_is_requested(  # noqa: E501
-        self, patch_generate_csr
+        self, mock_generate_csr: MagicMock
     ):
         private_key = generate_private_key()
         csr_in_relation_data = generate_csr(
@@ -498,7 +498,7 @@ class TestTLSCertificatesRequiresV4:
             private_key=private_key,
             common_name="new.example.com",
         )
-        patch_generate_csr.return_value = new_csr
+        mock_generate_csr.return_value = new_csr
         certificates_relation = scenario.Relation(
             endpoint="certificates",
             interface="tls-certificates",
@@ -997,7 +997,7 @@ class TestTLSCertificatesRequiresV4:
 
     @patch(LIB_DIR + ".CertificateRequestAttributes.generate_csr")
     def test_given_certificate_when_certificate_secret_expires_then_new_certificate_is_requested(  # noqa: E501
-        self, patch_generate_csr
+        self, mock_generate_csr: MagicMock
     ):
         private_key = generate_private_key()
         csr = generate_csr(
@@ -1022,7 +1022,7 @@ class TestTLSCertificatesRequiresV4:
             common_name="example.com",
         )
         assert csr != new_csr
-        patch_generate_csr.return_value = new_csr
+        mock_generate_csr.return_value = new_csr
 
         private_key_secret = Secret(
             {"private-key": private_key},
@@ -1114,7 +1114,7 @@ class TestTLSCertificatesRequiresV4:
 
     @patch(LIB_DIR + ".CertificateRequestAttributes.generate_csr")
     def test_given_certificate_when_renew_certificate_then_new_certificate_is_requested(
-        self, patch_generate_csr
+        self, mock_generate_csr: MagicMock
     ):
         private_key = generate_private_key()
         csr = generate_csr(
@@ -1139,7 +1139,7 @@ class TestTLSCertificatesRequiresV4:
             common_name="example.com",
         )
         assert csr != new_csr
-        patch_generate_csr.return_value = new_csr
+        mock_generate_csr.return_value = new_csr
 
         private_key_secret = Secret(
             {"private-key": private_key},


### PR DESCRIPTION
This change adds a pyright check to ensure that we add type hints to our code