### PR TITLE
test: Test upgrade path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,8 +185,15 @@ jobs:
           pipx uninstall tox
           sudo snap install astral-uv --classic
           uv tool install tox --with tox-uv
-      - name: Run tests using tox
+
+      # Only run upgrade test on PRs
+      - name: Run integration tests
+        run: tox -e integration-v4 -- --no-upgrade
+        if: ${{ github.ref_name == 'main' }}
+      - name: Run integration tests with upgrade tests
         run: tox -e integration-v4
+        if: ${{ github.ref_name != 'main' }}
+
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+markers = [
+    "upgrade: mark a test as an upgrade test",
+]
 
 # Linting tools configuration
 [tool.ruff]

--- a/tests/integration/v4/conftest.py
+++ b/tests/integration/v4/conftest.py
@@ -9,10 +9,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def pytest_configure(config: pytest.Config) -> None:
-    config.addinivalue_line("markers", "slow: mark test as slow to run")
-
-
 # Adapted from
 # https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
 def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]) -> None:

--- a/tests/integration/v4/conftest.py
+++ b/tests/integration/v4/conftest.py
@@ -1,0 +1,23 @@
+from typing import List
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--no-upgrade", action="store_true", default=False, help="do not run upgrade tests"
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+# Adapted from
+# https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]) -> None:
+    if config.getoption("--no-upgrade"):
+        skip_upgrade = pytest.mark.skip(reason="--no-upgrade option was given")
+        for item in items:
+            if "upgrade" in item.keywords:
+                item.add_marker(skip_upgrade)

--- a/tests/integration/v4/provider_charm/charmcraft.yaml
+++ b/tests/integration/v4/provider_charm/charmcraft.yaml
@@ -26,3 +26,7 @@ parts:
       - libssl-dev
       - pkg-config
       - rustc
+
+charm-libs:
+  - lib: tls-certificates-interface.tls_certificates
+    version: "4"

--- a/tests/integration/v4/provider_charm/src/charm.py
+++ b/tests/integration/v4/provider_charm/src/charm.py
@@ -10,9 +10,8 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
     ProviderCertificate,
     TLSCertificatesProvidesV4,
 )
-from ops import EventBase
+from ops import EventBase, main
 from ops.charm import CharmBase, CollectStatusEvent
-from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, SecretNotFoundError, WaitingStatus
 from self_signed_certificates import (
     generate_ca,

--- a/tests/integration/v4/requirer_charm/charmcraft.yaml
+++ b/tests/integration/v4/requirer_charm/charmcraft.yaml
@@ -61,3 +61,10 @@ config:
 actions:
   get-certificate:
     description: Returns the TLS Certificate.
+
+  renew-certificate:
+    description: Renews the TLS Certificate.
+
+charm-libs:
+  - lib: tls-certificates-interface.tls_certificates
+    version: "4"

--- a/tests/integration/v4/requirer_charm/src/charm.py
+++ b/tests/integration/v4/requirer_charm/src/charm.py
@@ -9,8 +9,8 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
     Mode,
     TLSCertificatesRequiresV4,
 )
+from ops import main
 from ops.charm import ActionEvent, CharmBase, CollectStatusEvent
-from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 
@@ -27,6 +27,16 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
         )
         self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
         self.framework.observe(self.on.get_certificate_action, self._on_get_certificate_action)
+        self.framework.observe(self.on.renew_certificate_action, self._on_renew_certificate_action)
+
+    def _on_renew_certificate_action(self, event: ActionEvent) -> None:
+        cert, _private_key = self.certificates.get_assigned_certificate(
+            self._get_certificate_request()
+        )
+        if not cert:
+            event.fail("Certificate not available")
+            return
+        self.certificates.renew_certificate(cert)
 
     def _on_collect_unit_status(self, event: CollectStatusEvent):
         if not self._relation_created("certificates"):

--- a/tests/integration/v4/test_integration_v4.py
+++ b/tests/integration/v4/test_integration_v4.py
@@ -2,10 +2,14 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import contextlib
 import logging
+import os
 import shutil
+import subprocess
 import time
 
+import pytest
 from certificates import Certificate
 from pytest_operator.plugin import OpsTest
 
@@ -19,13 +23,123 @@ TLS_CERTIFICATES_REQUIRER_APP_NAME = "tls-certificates-requirer"
 
 
 def copy_lib_content() -> None:
+    """Copy the latest lib content to the requirer and provider charm."""
     shutil.copyfile(src=LIB_DIR, dst=f"{REQUIRER_CHARM_DIR}/{LIB_DIR}")
     shutil.copyfile(src=LIB_DIR, dst=f"{PROVIDER_CHARM_DIR}/{LIB_DIR}")
+
+
+def remove_existing_lib_and_fetch_latest() -> None:
+    """Remove the existing lib and fetch the latest lib with charmcraft.
+
+    This will be the latest _released_ of the interface library, as opposed
+    to the one that is associated with this version of the code.
+    """
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(
+            f"{REQUIRER_CHARM_DIR}/lib/charms/tls_certificates_interface/v4/tls_certificates.py"
+        )
+        os.remove(
+            f"{PROVIDER_CHARM_DIR}/lib/charms/tls_certificates_interface/v4/tls_certificates.py"
+        )
+    # fetch latest lib with charmcraft
+    subprocess.run(["charmcraft", "fetch-libs"], cwd=REQUIRER_CHARM_DIR, check=True)
+    subprocess.run(["charmcraft", "fetch-libs"], cwd=PROVIDER_CHARM_DIR, check=True)
 
 
 class TestIntegration:
     requirer_charm = None
     provider_charm = None
+
+    @pytest.mark.upgrade
+    async def test_given_main_deployed_when_upgraded_then_certs_are_retrieved(
+        self, ops_test: OpsTest
+    ):
+        assert ops_test.model
+
+        # deploy with the latest version of the lib
+        remove_existing_lib_and_fetch_latest()
+        TestIntegration.requirer_charm = await ops_test.build_charm(f"{REQUIRER_CHARM_DIR}/")
+        TestIntegration.provider_charm = await ops_test.build_charm(f"{PROVIDER_CHARM_DIR}/")
+
+        await ops_test.model.deploy(
+            TestIntegration.requirer_charm,
+            application_name=TLS_CERTIFICATES_REQUIRER_APP_NAME,
+            series="jammy",
+        )
+        await ops_test.model.deploy(
+            TestIntegration.provider_charm,
+            application_name=TLS_CERTIFICATES_PROVIDER_APP_NAME,
+            series="jammy",
+        )
+        # create a relation to requests certs
+        await ops_test.model.add_relation(
+            relation1=TLS_CERTIFICATES_REQUIRER_APP_NAME,
+            relation2=TLS_CERTIFICATES_PROVIDER_APP_NAME,
+        )
+
+        await ops_test.model.wait_for_idle(
+            apps=[TLS_CERTIFICATES_REQUIRER_APP_NAME, TLS_CERTIFICATES_PROVIDER_APP_NAME],
+            status="active",
+            timeout=1000,
+        )
+        # retrieve certs and validate
+        requirer_unit = ops_test.model.units[f"{TLS_CERTIFICATES_REQUIRER_APP_NAME}/0"]
+        assert requirer_unit
+
+        action = await requirer_unit.run_action(action_name="get-certificate")
+
+        action_output = await ops_test.model.get_action_output(
+            action_uuid=action.entity_id, wait=60
+        )
+        assert action_output["return-code"] == 0
+        assert "ca" in action_output and action_output["ca"] is not None
+        assert "certificate" in action_output and action_output["certificate"] is not None
+        assert "chain" in action_output and action_output["chain"] is not None
+
+        # upgrade to the new version of the lib
+        copy_lib_content()
+        TestIntegration.requirer_charm = await ops_test.build_charm(f"{REQUIRER_CHARM_DIR}/")
+        TestIntegration.provider_charm = await ops_test.build_charm(f"{PROVIDER_CHARM_DIR}/")
+        await ops_test.model.applications[TLS_CERTIFICATES_REQUIRER_APP_NAME].refresh(
+            path=TestIntegration.requirer_charm
+        )
+        await ops_test.model.applications[TLS_CERTIFICATES_PROVIDER_APP_NAME].refresh(
+            path=TestIntegration.provider_charm
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[TLS_CERTIFICATES_REQUIRER_APP_NAME, TLS_CERTIFICATES_PROVIDER_APP_NAME],
+            status="active",
+            timeout=1000,
+        )
+
+        # renew the certificate
+        action = await requirer_unit.run_action(action_name="renew-certificate")
+        action_output = await ops_test.model.get_action_output(
+            action_uuid=action.entity_id, wait=60
+        )
+        assert action_output["return-code"] == 0
+        await ops_test.model.wait_for_idle(
+            apps=[TLS_CERTIFICATES_REQUIRER_APP_NAME, TLS_CERTIFICATES_PROVIDER_APP_NAME],
+            status="active",
+            timeout=1000,
+        )
+        # retrieve certs and validate
+        requirer_unit = ops_test.model.units[f"{TLS_CERTIFICATES_REQUIRER_APP_NAME}/0"]
+        assert requirer_unit
+
+        action = await requirer_unit.run_action(action_name="get-certificate")
+
+        action_output = await ops_test.model.get_action_output(
+            action_uuid=action.entity_id, wait=60
+        )
+        assert action_output["return-code"] == 0
+        assert "ca" in action_output and action_output["ca"] is not None
+        assert "certificate" in action_output and action_output["certificate"] is not None
+        assert "chain" in action_output and action_output["chain"] is not None
+
+        # tear down so that the rest of the tests can run as normal
+        await ops_test.model.applications[TLS_CERTIFICATES_REQUIRER_APP_NAME].remove()
+        await ops_test.model.applications[TLS_CERTIFICATES_PROVIDER_APP_NAME].remove()
 
     async def test_given_charms_packed_when_deploy_charm_then_status_is_blocked(
         self, ops_test: OpsTest


### PR DESCRIPTION
Adds an integration test to deploy the the provider and requirer charms with the latest published lib first, request a certificate, then refresh the charm with the latest revision and renew the certificate.

This will hopefully catch issues with upgrading between revisions.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
