### PR TITLE
fix: writing secret content bug from ops

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -1145,6 +1145,7 @@ class TLSCertificatesRequiresV4(Object):
     def _regenerate_private_key(self) -> None:
         secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
         secret.set_content({"private-key": str(generate_private_key())})
+        secret.get_content(refresh=True)
 
     def _private_key_generated(self) -> bool:
         try:
@@ -1370,6 +1371,7 @@ class TLSCertificatesRequiresV4(Object):
                         secret.set_info(
                             expire=provider_certificate.certificate.expiry_time,
                         )
+                        secret.get_content(refresh=True)
                     except SecretNotFoundError:
                         logger.debug("Creating new secret with label %s", secret_label)
                         secret = self.charm.unit.add_secret(

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -52,7 +52,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 PYDEPS = ["cryptography", "pydantic"]
 

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
@@ -1226,31 +1226,3 @@ class TestTLSCertificatesRequiresV4:
                 )
             }
         )
-
-    def test_given_private_key_generated_when_regenerate_private_key_then_new_private_key_is_generated_in_same_hook(  # noqa: E501
-        self,
-    ):
-        initial_private_key = "whatever the initial private key is"
-        certificates_relation = scenario.Relation(
-            endpoint="certificates",
-            interface="tls-certificates",
-            remote_app_name="certificate-requirer",
-        )
-
-        state_in = scenario.State(
-            relations={certificates_relation},
-            config={"common_name": "example.com"},
-            secrets={
-                Secret(
-                    {"private-key": initial_private_key},
-                    label=f"{LIBID}-private-key-0",
-                    owner="unit",
-                )
-            },
-        )
-
-        with self.ctx(self.ctx.on.update_status(), state_in) as manager:
-            charm: DummyTLSCertificatesRequirerCharm = manager.charm  # type: ignore
-            old_private_key = charm.certificates.private_key
-            charm.certificates._regenerate_private_key()
-            assert charm.certificates.private_key != old_private_key

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
@@ -1226,3 +1226,31 @@ class TestTLSCertificatesRequiresV4:
                 )
             }
         )
+
+    def test_given_private_key_generated_when_regenerate_private_key_then_new_private_key_is_generated_in_same_hook(  # noqa: E501
+        self,
+    ):
+        initial_private_key = "whatever the initial private key is"
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-requirer",
+        )
+
+        state_in = scenario.State(
+            relations={certificates_relation},
+            config={"common_name": "example.com"},
+            secrets={
+                Secret(
+                    {"private-key": initial_private_key},
+                    label=f"{LIBID}-private-key-0",
+                    owner="unit",
+                )
+            },
+        )
+
+        with self.ctx(self.ctx.on.update_status(), state_in) as manager:
+            charm: DummyTLSCertificatesRequirerCharm = manager.charm  # type: ignore
+            old_private_key = charm.certificates.private_key
+            charm.certificates._regenerate_private_key()
+            assert charm.certificates.private_key != old_private_key


### PR DESCRIPTION
# Description

Hello team,

When trying to rotate the certificates by setting the private key manually in the etcd charm, I noticed a bug in the ops framework that caused the TLS lib to fail to load the newly updated private key in the same hook.

As shown in this [proof-charm](https://github.com/skourta/juju-update-secret-issue) running the `rotate-private-key` action will update the private key but the value read after the regeneration is still the old one.

```python
    def _on_rotate_private_key(self, event: ops.ActionEvent) -> None:
        old_value = self.certificates.private_key
        self.certificates._regenerate_private_key()
        new_value = self.certificates.private_key

        event.set_results(
            {
                "old-value": old_value,
                "new-value": new_value,
                "z-key-rotated": old_value != new_value,
            }
        )
```

This is due to a bug in the `ops` framework as reported on [matrix](https://matrix.to/#/!eNCNzcteYUDDYpStsu:ubuntu.com/$lAR3mxTa2omPmeIPW2e61yapVYuv9iujj6oOc7vX4_0?via=ubuntu.com&via=matrix.org). There seems to be a cache on the `set_content` method that is only written to the secret when the hook successfully exits or when the `get_content(refresh=True)` is called.

This PR fixes the issue by calling the `get_content(refresh=True)` method after the private key is regenerated to ensure the new value is read correctly.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
