### PR TITLE
chore: Add tests to make sure mode is respected

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -52,7 +52,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 PYDEPS = ["cryptography", "pydantic"]
 

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -171,7 +171,7 @@ class _CertificateSigningRequest(BaseModel):
 class _ProviderApplicationData(_DatabagModel):
     """Provider application data model."""
 
-    certificates: List[_Certificate]
+    certificates: List[_Certificate] = []
 
 
 class _RequirerData(_DatabagModel):
@@ -180,7 +180,7 @@ class _RequirerData(_DatabagModel):
     The same model is used for the unit and application data.
     """
 
-    certificate_signing_requests: List[_CertificateSigningRequest]
+    certificate_signing_requests: List[_CertificateSigningRequest] = []
 
 
 class Mode(Enum):

--- a/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/dummy_requirer_charm/src/charm.py
@@ -22,7 +22,7 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
             charm=self,
             relationship_name="certificates",
             certificate_requests=certificate_requests,
-            mode=Mode.UNIT,
+            mode=self._app_or_unit(),
             refresh_events=[self.on.config_changed],
         )
         self.framework.observe(
@@ -87,6 +87,10 @@ class DummyTLSCertificatesRequirerCharm(CharmBase):
         self.certificates.renew_certificate(
             certificate=certificate,
         )
+
+    def _app_or_unit(self) -> Mode:
+        """Return Unit by default, This function is mocked in tests to return App."""
+        return Mode.UNIT
 
     def _get_config_common_name(self) -> str:
         return cast(str, self.model.config.get("common_name"))

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_provides.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_provides.py
@@ -888,9 +888,7 @@ class TestTLSCertificatesProvidesV4:
 
         state_out = self.ctx.run(self.ctx.on.relation_changed(certificates_relation), state_in)
 
-        assert state_out.get_relation(certificates_relation.id).local_app_data == {
-            "certificates": "[]"
-        }
+        assert state_out.get_relation(certificates_relation.id).local_app_data == {}
 
     def test_given_fulfilled_certificate_requests_when_relation_changed_then_certificates_removed(
         self,

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4_requires.py
@@ -466,7 +466,7 @@ class TestTLSCertificatesRequiresV4:
                     endpoint="certificates",
                     interface="tls-certificates",
                     remote_app_name="certificate-requirer",
-                    local_unit_data={"certificate_signing_requests": "[]"},
+                    local_unit_data={},
                 ),
             }
         )


### PR DESCRIPTION
# Description

Fixes #302 

~~Makes sure that the mode chosen by requirer (Unit or APP) is respected.~~

- This PR adds a test to ensure that the csrs are added to the correct databags depending on Mode.
- Allows the relation databag to be empty without failing validation (This will reduce the number of log entries with validation failures)

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
