### PR TITLE
fix: Do not use destructive mode on upload to use LXD

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -19,6 +19,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "edge"
           upload-image: "false"
+          destructive-mode: "false"
 
       - name: Publish libs
         env:


### PR DESCRIPTION
# Description

The charm and libraries currently fail to publish after an update to the version of Ubuntu used on the runners. This is due to charmcraft running in destructive mode and directly using the runner to pack the charm, instead of using LXD.

This disables destructive mode, forcing charmcraft to use LXD and not depend directly on the runner's OS version.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
