### PR TITLE
fix: Ensure secret exists before removal to prevent error state

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -1064,8 +1064,8 @@ class TLSCertificatesRequiresV4(Object):
     def _mode_is_valid(self, mode: Mode) -> bool:
         return mode in [Mode.UNIT, Mode.APP]
 
-    def _ensure_secret_exists(self, secret: Secret) -> None:
-        secret.get_info()
+    def _validate_secret_exists(self, secret: Secret) -> None:
+        secret.get_info()  # Will raise `SecretNotFoundError` if the secret does not exist
 
     def _on_secret_remove(self, event: SecretRemoveEvent) -> None:
         """Handle Secret Removed Event."""
@@ -1074,7 +1074,7 @@ class TLSCertificatesRequiresV4(Object):
             # the unit could be stuck in an error state. See the docstring of
             # `remove_revision` and the below issue for more information.
             # https://github.com/juju/juju/issues/19036
-            self._ensure_secret_exists(event.secret)
+            self._validate_secret_exists(event.secret)
             event.secret.remove_revision(event.revision)
         except SecretNotFoundError:
             logger.warning(

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -32,7 +32,7 @@ from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
-from ops import BoundEvent, CharmBase, CharmEvents, SecretExpiredEvent, SecretRemoveEvent
+from ops import BoundEvent, CharmBase, CharmEvents, Secret, SecretExpiredEvent, SecretRemoveEvent
 from ops.framework import EventBase, EventSource, Handle, Object
 from ops.jujuversion import JujuVersion
 from ops.model import (
@@ -52,7 +52,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 PYDEPS = [
     "cryptography>=43.0.0",
@@ -1064,9 +1064,17 @@ class TLSCertificatesRequiresV4(Object):
     def _mode_is_valid(self, mode: Mode) -> bool:
         return mode in [Mode.UNIT, Mode.APP]
 
+    def _ensure_secret_exists(self, secret: Secret) -> None:
+        secret.get_info()
+
     def _on_secret_remove(self, event: SecretRemoveEvent) -> None:
         """Handle Secret Removed Event."""
         try:
+            # Ensure the secret exists before trying to remove it, otherwise
+            # the unit could be stuck in an error state. See the docstring of
+            # `remove_revision` and the below issue for more information.
+            # https://github.com/juju/juju/issues/19036
+            self._ensure_secret_exists(event.secret)
             event.secret.remove_revision(event.revision)
         except SecretNotFoundError:
             logger.warning(


### PR DESCRIPTION
Ensure the secret that should contain the secret revision exists before trying to remove it, otherwise the unit could be stuck in an error state. 

See https://github.com/juju/juju/issues/19036 for more information.

Fixes the build for https://github.com/canonical/vault-k8s-operator/pull/552

~~Requires #326~~ 

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
