### PR TITLE
build: Disable major version updates for juju to prevent breaking integration tests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,13 @@
       "enabled": false
     },
     {
+      // Bumping "juju" to a new major version breaks the integration tests
+      // which individually test each version of Juju
+      "matchPackageNames": ["juju"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub actions"
     },


### PR DESCRIPTION
This is an attempt (I don't really know how to test this other than to merge and see if it works) to prevent renovate from updating the version of `python-libjuju` otherwise it will keep coming back: https://github.com/canonical/tls-certificates-interface/pull/323, https://github.com/canonical/tls-certificates-interface/pull/320

These versions of `python-libjuju` are explicitly set so that we can test different versions of Juju. We do not want the latest version.

~~Requires #326~~

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
