### PR TITLE
fix: Fixes from_string in CertificateSigningRequest

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -52,7 +52,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 PYDEPS = [
     "cryptography>=43.0.0",
@@ -404,12 +404,17 @@ class CertificateSigningRequest:
         )
         locality_name = csr_object.subject.get_attributes_for_oid(NameOID.LOCALITY_NAME)
         organization_name = csr_object.subject.get_attributes_for_oid(NameOID.ORGANIZATION_NAME)
+        organizational_unit = csr_object.subject.get_attributes_for_oid(
+            NameOID.ORGANIZATIONAL_UNIT_NAME
+        )
         email_address = csr_object.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
         try:
             sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
             sans_dns = frozenset(sans.get_values_for_type(x509.DNSName))
             sans_ip = frozenset([str(san) for san in sans.get_values_for_type(x509.IPAddress)])
-            sans_oid = frozenset([str(san) for san in sans.get_values_for_type(x509.RegisteredID)])
+            sans_oid = frozenset(
+                [san.dotted_string for san in sans.get_values_for_type(x509.RegisteredID)]
+            )
         except x509.ExtensionNotFound:
             sans = frozenset()
             sans_dns = frozenset()
@@ -424,6 +429,7 @@ class CertificateSigningRequest:
             else None,
             locality_name=str(locality_name[0].value) if locality_name else None,
             organization=str(organization_name[0].value) if organization_name else None,
+            organizational_unit=str(organizational_unit[0].value) if organizational_unit else None,
             email_address=str(email_address[0].value) if email_address else None,
             sans_dns=sans_dns,
             sans_ip=sans_ip,

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
@@ -190,6 +190,7 @@ def test_given_certificate_request_attributes_when_generate_csr_then_csr_is_gene
     assert csr.state_or_province_name == "Quebec"
     assert csr.locality_name == "Montreal"
 
+
 # Generate CA
 
 
@@ -307,6 +308,7 @@ def test_given_csr_for_ca_when_generate_certificate_then_certificate_generated_w
 
 
 # from_string and from_csr
+
 
 def test_given_csr_string_when_from_string_then_certificate_signing_request_is_created_correctly():
     private_key = generate_private_key()

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
@@ -18,6 +18,11 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import load_pem_private_key, pkcs12
 
+from lib.charms.tls_certificates_interface.v4.tls_certificates import (
+    Certificate,
+    CertificateRequestAttributes,
+    CertificateSigningRequest,
+)
 from tests.unit.charms.tls_certificates_interface.v4.certificates import (
     generate_private_key as generate_private_key_helper,
 )
@@ -155,6 +160,36 @@ def test_given_ipv6_sans_when_generate_csr_then_csr_contains_ipv6_sans():
     assert IPv6Address("2001:db8::2") in sans_ip
 
 
+def test_given_certificate_request_attributes_when_generate_csr_then_csr_is_generated_correctly():
+    private_key = generate_private_key()
+
+    csr = generate_csr(
+        private_key=private_key,
+        common_name="example.com",
+        sans_dns=frozenset(["example.com"]),
+        sans_ip=frozenset(["1.2.3.4"]),
+        sans_oid=frozenset(["1.2.3.4"]),
+        email_address="banana@gmail.com",
+        organization="Example",
+        organizational_unit="Example Unit",
+        country_name="CA",
+        state_or_province_name="Quebec",
+        locality_name="Montreal",
+    )
+    assert csr.common_name == "example.com"
+    assert csr.sans_dns == frozenset(["example.com"])
+    assert csr.sans_ip == frozenset(["1.2.3.4"])
+    assert csr.sans_oid is not None
+    assert len(csr.sans_oid) == 1
+    oid = next(iter(csr.sans_oid))
+    assert "1.2.3.4" in str(oid)
+    assert csr.email_address == "banana@gmail.com"
+    assert csr.organization == "Example"
+    assert csr.organizational_unit == "Example Unit"
+    assert csr.country_name == "CA"
+    assert csr.state_or_province_name == "Quebec"
+    assert csr.locality_name == "Montreal"
+
 # Generate CA
 
 
@@ -167,6 +202,7 @@ def test_given_ca_certificate_attributes_when_generate_ca_then_ca_is_generated_c
         common_name="certifier.example.com",
         sans_dns=frozenset(["certifier.example.com"]),
         sans_ip=frozenset(["1.2.3.4"]),
+        sans_oid=frozenset(["1.2.3.4"]),
         email_address="banana@gmail.com",
         organization="Example",
         organizational_unit="Example Unit",
@@ -187,7 +223,10 @@ def test_given_ca_certificate_attributes_when_generate_ca_then_ca_is_generated_c
     assert ca_certificate.locality_name == "Montreal"
     assert ca_certificate.sans_dns == frozenset(["certifier.example.com"])
     assert ca_certificate.sans_ip == frozenset(["1.2.3.4"])
-    assert ca_certificate.sans_oid == frozenset()
+    assert ca_certificate.sans_oid is not None
+    assert len(ca_certificate.sans_oid) == 1
+    oid = next(iter(ca_certificate.sans_oid))
+    assert "1.2.3.4" in str(oid)
 
 
 # Generate Certificate
@@ -265,3 +304,114 @@ def test_given_csr_for_ca_when_generate_certificate_then_certificate_generated_w
     assert certificate.email_address is None
     assert certificate.country_name is None
     assert certificate.locality_name == "wherever"
+
+
+# from_string and from_csr
+
+def test_given_csr_string_when_from_string_then_certificate_signing_request_is_created_correctly():
+    private_key = generate_private_key()
+    csr = generate_csr(
+        private_key=private_key,
+        common_name="example.com",
+        sans_dns=frozenset(["example.com"]),
+        sans_ip=frozenset(["1.2.3.4"]),
+        sans_oid=frozenset(["1.2.3.4"]),
+        email_address="banana@gmail.com",
+        organization="Example",
+        organizational_unit="Example Unit",
+        country_name="CA",
+        state_or_province_name="Quebec",
+        locality_name="Montreal",
+    )
+    csr_from_string = CertificateSigningRequest.from_string(str(csr))
+    assert csr_from_string.common_name == "example.com"
+    assert csr_from_string.sans_dns == frozenset(["example.com"])
+    assert csr_from_string.sans_ip == frozenset(["1.2.3.4"])
+    assert csr_from_string.sans_oid == frozenset(["1.2.3.4"])
+    assert csr_from_string.email_address == "banana@gmail.com"
+    assert csr_from_string.organization == "Example"
+    assert csr_from_string.organizational_unit == "Example Unit"
+    assert csr_from_string.country_name == "CA"
+    assert csr_from_string.state_or_province_name == "Quebec"
+    assert csr_from_string.locality_name == "Montreal"
+
+
+def test_given_certificate_signin_request_when_from_csr_then_attributes_are_correctly_parsed():
+    private_key = generate_private_key()
+    csr = generate_csr(
+        private_key=private_key,
+        common_name="example.com",
+        sans_dns=frozenset(["example.com"]),
+        sans_ip=frozenset(["1.2.3.4"]),
+        sans_oid=frozenset(["1.2.3.4"]),
+        email_address="banana@gmail.com",
+        organization="Example",
+        organizational_unit="Example Unit",
+        country_name="CA",
+        state_or_province_name="Quebec",
+        locality_name="Montreal",
+    )
+    csr_from_string = CertificateSigningRequest.from_string(str(csr))
+    attributes = CertificateRequestAttributes.from_csr(csr_from_string, is_ca=False)
+    assert attributes.common_name == "example.com"
+    assert attributes.sans_dns == frozenset(["example.com"])
+    assert attributes.sans_ip == frozenset(["1.2.3.4"])
+    assert attributes.sans_oid == frozenset(["1.2.3.4"])
+    assert attributes.email_address == "banana@gmail.com"
+    assert attributes.organization == "Example"
+    assert attributes.organizational_unit == "Example Unit"
+    assert attributes.country_name == "CA"
+    assert attributes.state_or_province_name == "Quebec"
+    assert attributes.locality_name == "Montreal"
+
+
+def test_given_certificate_string_when_from_string_then_certificate_is_created_correctly():
+    private_key = generate_private_key()
+    csr = generate_csr(
+        private_key=private_key,
+        common_name="example.com",
+        sans_dns=frozenset(["example.com"]),
+        sans_ip=frozenset(["1.2.3.4"]),
+        sans_oid=frozenset(["1.2.3.4"]),
+        email_address="banana@gmail.com",
+        organization="Example",
+        organizational_unit="Example Unit",
+        country_name="CA",
+        state_or_province_name="Quebec",
+        locality_name="Montreal",
+    )
+    ca_private_key = generate_private_key()
+    ca_certificate = generate_ca(
+        private_key=ca_private_key,
+        validity=timedelta(days=365),
+        common_name="certifier.example.com",
+        sans_dns=frozenset(["certifier.example.com"]),
+    )
+    certificate = generate_certificate(
+        csr=csr,
+        ca=ca_certificate,
+        ca_private_key=ca_private_key,
+        validity=timedelta(days=200),
+        is_ca=False,
+    )
+    certificate_from_string = Certificate.from_string(str(certificate))
+    assert certificate_from_string.common_name == "example.com"
+    expected_expiry = datetime.now(timezone.utc) + timedelta(days=200)
+    assert abs(certificate_from_string.expiry_time - expected_expiry) <= timedelta(seconds=2)
+    expected_validity_start_time = datetime.now(timezone.utc)
+    assert abs(
+        certificate_from_string.validity_start_time - expected_validity_start_time
+    ) <= timedelta(seconds=2)
+    assert certificate_from_string.sans_dns == frozenset(["example.com"])
+    assert certificate_from_string.sans_ip == frozenset(["1.2.3.4"])
+    assert certificate_from_string.sans_oid is not None
+    assert len(certificate_from_string.sans_oid) == 1
+    oid = next(iter(certificate_from_string.sans_oid))
+    assert "1.2.3.4" in str(oid)
+    assert certificate_from_string.email_address == "banana@gmail.com"
+    assert certificate_from_string.organization == "Example"
+    assert certificate_from_string.organizational_unit == "Example Unit"
+    assert certificate_from_string.country_name == "CA"
+    assert certificate_from_string.state_or_province_name == "Quebec"
+    assert certificate_from_string.locality_name == "Montreal"
+    assert certificate_from_string.is_ca is False


### PR DESCRIPTION
# Description

The `from_string` function in the `CertificateSigningRequest` class creates an object from a csr string, the function currently does not extract the organizational_unit from the string and doesn't convert the sans_oid from `FrozenSet[ObjectIdentifier]` to `FrozenSet[str]` correctly. This PR fixes those issues.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
