### PR TITLE
feat: Allows the requirer to set the value of add_unique_id_to_subject_name in the CertificateRequestAttributes

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -409,7 +409,9 @@ class CertificateSigningRequest:
             NameOID.ORGANIZATIONAL_UNIT_NAME
         )
         email_address = csr_object.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
-        unique_identifier = csr_object.subject.get_attributes_for_oid(NameOID.X500_UNIQUE_IDENTIFIER)
+        unique_identifier = csr_object.subject.get_attributes_for_oid(
+            NameOID.X500_UNIQUE_IDENTIFIER
+        )
         try:
             sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
             sans_dns = frozenset(sans.get_values_for_type(x509.DNSName))

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -52,7 +52,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 PYDEPS = [
     "cryptography>=43.0.0",
@@ -378,6 +378,7 @@ class CertificateSigningRequest:
     country_name: Optional[str] = None
     state_or_province_name: Optional[str] = None
     locality_name: Optional[str] = None
+    has_unique_identifier: bool = False
 
     def __eq__(self, other: object) -> bool:
         """Check if two CertificateSigningRequest objects are equal."""
@@ -408,6 +409,7 @@ class CertificateSigningRequest:
             NameOID.ORGANIZATIONAL_UNIT_NAME
         )
         email_address = csr_object.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
+        unique_identifier = csr_object.subject.get_attributes_for_oid(NameOID.X500_UNIQUE_IDENTIFIER)
         try:
             sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
             sans_dns = frozenset(sans.get_values_for_type(x509.DNSName))
@@ -434,6 +436,7 @@ class CertificateSigningRequest:
             sans_dns=sans_dns,
             sans_ip=sans_ip,
             sans_oid=sans_oid,
+            has_unique_identifier=bool(unique_identifier),
         )
 
     def matches_private_key(self, key: PrivateKey) -> bool:
@@ -508,6 +511,7 @@ class CertificateRequestAttributes:
     state_or_province_name: Optional[str] = None
     locality_name: Optional[str] = None
     is_ca: bool = False
+    add_unique_id_to_subject_name: bool = True
 
     def is_valid(self) -> bool:
         """Check whether the certificate request is valid."""
@@ -539,6 +543,7 @@ class CertificateRequestAttributes:
             country_name=self.country_name,
             state_or_province_name=self.state_or_province_name,
             locality_name=self.locality_name,
+            add_unique_id_to_subject_name=self.add_unique_id_to_subject_name,
         )
 
     @classmethod
@@ -556,6 +561,7 @@ class CertificateRequestAttributes:
             state_or_province_name=csr.state_or_province_name,
             locality_name=csr.locality_name,
             is_ca=is_ca,
+            add_unique_id_to_subject_name=csr.has_unique_identifier,
         )
 
 

--- a/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
+++ b/tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py
@@ -324,6 +324,7 @@ def test_given_csr_string_when_from_string_then_certificate_signing_request_is_c
         country_name="CA",
         state_or_province_name="Quebec",
         locality_name="Montreal",
+        add_unique_id_to_subject_name=False,
     )
     csr_from_string = CertificateSigningRequest.from_string(str(csr))
     assert csr_from_string.common_name == "example.com"
@@ -336,6 +337,7 @@ def test_given_csr_string_when_from_string_then_certificate_signing_request_is_c
     assert csr_from_string.country_name == "CA"
     assert csr_from_string.state_or_province_name == "Quebec"
     assert csr_from_string.locality_name == "Montreal"
+    assert not csr_from_string.has_unique_identifier
 
 
 def test_given_certificate_signin_request_when_from_csr_then_attributes_are_correctly_parsed():


### PR DESCRIPTION
# Description

`add_unique_id_to_subject_name` is currently always set to True in the `generate_csr` function, this PR allows the requirer to decided its value.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
