### PR TITLE
feat: add KeyUsage extension to all certificates generated

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -52,7 +52,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 PYDEPS = [
     "cryptography>=43.0.0",
@@ -943,6 +943,21 @@ def _get_certificate_request_extensions(
             critical=True,
             value=x509.BasicConstraints(ca=is_ca, path_length=None),
         ),
+        x509.Extension(
+            ExtensionOID.KEY_USAGE,
+            critical=True,
+            value=x509.KeyUsage(
+                digital_signature=False,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=is_ca,
+                crl_sign=is_ca,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+        ),
     ]
     sans: List[x509.GeneralName] = []
     try:
@@ -968,25 +983,6 @@ def _get_certificate_request_extensions(
                 oid=ExtensionOID.SUBJECT_ALTERNATIVE_NAME,
                 critical=False,
                 value=x509.SubjectAlternativeName(sans),
-            )
-        )
-
-    if is_ca:
-        cert_extensions_list.append(
-            x509.Extension(
-                ExtensionOID.KEY_USAGE,
-                critical=True,
-                value=x509.KeyUsage(
-                    digital_signature=False,
-                    content_commitment=False,
-                    key_encipherment=False,
-                    data_encipherment=False,
-                    key_agreement=False,
-                    key_cert_sign=True,
-                    crl_sign=True,
-                    encipher_only=False,
-                    decipher_only=False,
-                ),
             )
         )
 

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -945,7 +945,7 @@ def _get_certificate_request_extensions(
         ),
         x509.Extension(
             ExtensionOID.KEY_USAGE,
-            critical=True,
+            critical=is_ca,
             value=x509.KeyUsage(
                 digital_signature=False,
                 content_commitment=False,


### PR DESCRIPTION
# Description

Enhancements to certificate request extension handling:

* [`lib/charms/tls_certificates_interface/v4/tls_certificates.py`](diffhunk://#diff-93bc89551f2781264804fc1a156d1bf7be684bb1f83337ceed2f625ccf101f16R946-R960): Added the `KEY_USAGE` extension to the certificate request extensions list to ensure proper handling of key usage attributes. [[1]](diffhunk://#diff-93bc89551f2781264804fc1a156d1bf7be684bb1f83337ceed2f625ccf101f16R946-R960) [[2]](diffhunk://#diff-93bc89551f2781264804fc1a156d1bf7be684bb1f83337ceed2f625ccf101f16L974-L992)

Improvements to test coverage:

* [`tests/unit/charms/tls_certificates_interface/v4/test_tls_certificates_v4.py`](diffhunk://#diff-359bb8102a367647c53e25f978873ea58ffa676e477aaff7f7f8613f4e49fec8R231-R239): Added assertions to verify the presence and correctness of the `BasicConstraints` and `KeyUsage` extensions in generated certificates. [[1]](diffhunk://#diff-359bb8102a367647c53e25f978873ea58ffa676e477aaff7f7f8613f4e49fec8R231-R239) [[2]](diffhunk://#diff-359bb8102a367647c53e25f978873ea58ffa676e477aaff7f7f8613f4e49fec8R281-R289) [[3]](diffhunk://#diff-359bb8102a367647c53e25f978873ea58ffa676e477aaff7f7f8613f4e49fec8R327-R334)

Version increment:

* [`lib/charms/tls_certificates_interface/v4/tls_certificates.py`](diffhunk://#diff-93bc89551f2781264804fc1a156d1bf7be684bb1f83337ceed2f625ccf101f16L55-R55): Incremented `LIBPATCH` version from 13 to 14.
## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
