### PR TITLE
chore: Use Jubilant for v2 integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
           sudo snap install astral-uv --classic
           uv tool install tox --with tox-uv
       - name: Run tests using tox
-        run: tox -e integration-v2-juju-2
+        run: tox -e integration-v2
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4
@@ -93,7 +93,7 @@ jobs:
           sudo snap install astral-uv --classic
           uv tool install tox --with tox-uv
       - name: Run tests using tox
-        run: tox -e integration-v2-juju-3
+        run: tox -e integration-v2
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,9 @@ jobs:
     name: Integration tests for tls interface v2 (Juju 2.9)
     runs-on: ubuntu-24.04
     needs:
-      - build
+      - unit-tests-with-coverage
+      - lint-report
+      - static-analysis
     steps:
       - uses: actions/checkout@v4
       - name: Setup operator environment
@@ -78,7 +80,9 @@ jobs:
     name: Integration tests for tls interface v2 (Juju 3.x)
     runs-on: ubuntu-24.04
     needs:
-      - build
+      - unit-tests-with-coverage
+      - lint-report
+      - static-analysis
     steps:
       - uses: actions/checkout@v4
       - name: Setup operator environment
@@ -111,7 +115,9 @@ jobs:
     name: Integration tests for tls interface v3
     runs-on: ubuntu-24.04
     needs:
-      - build
+      - unit-tests-with-coverage
+      - lint-report
+      - static-analysis
     steps:
       - uses: actions/checkout@v4
       - name: Setup operator environment
@@ -144,7 +150,9 @@ jobs:
     name: Integration tests for tls interface v4
     runs-on: ubuntu-24.04
     needs:
-      - build
+      - unit-tests-with-coverage
+      - lint-report
+      - static-analysis
     steps:
       - uses: actions/checkout@v4
       - name: Setup operator environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,30 +14,17 @@ dependencies = [
 [dependency-groups]
 test = [
     "coverage[toml]",
-    "pytest",
+    "jubilant",
+    "juju>3",
+    "ops[testing]",
     "pytest-operator",
     "pytest-asyncio==0.21.2",
-    "ops[testing]",
+    "pytest",
 ]
 dev = [
     "codespell",
     "pyright",
     "ruff",
-]
-test-juju-2 = [
-    "juju==2.9.49.1",
-    "websockets==13.1",
-]
-test-juju-3 = [
-    "juju>3"
-]
-
-[tool.uv]
-conflicts = [
-    [
-        { group = "test-juju-2" },
-        { group = "test-juju-3" },
-    ],
 ]
 
 # Testing tools configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 [dependency-groups]
 test = [
     "coverage[toml]",
-    "jubilant",
+    "jubilant==0.4.1",
     "juju>3",
     "ops[testing]",
     "pytest-operator",

--- a/tests/integration/v2/conftest.py
+++ b/tests/integration/v2/conftest.py
@@ -8,6 +8,17 @@ import pytest
 
 @pytest.fixture(scope="session", autouse=True)
 def patched_jubilant():
+    """Patch Jubilant AppStatusRelation for Juju 2.9 support.
+
+    Jubilant does not support Juju 2.9, and this workaround is required
+    as the JSON format of the CLI is not the same for the relation field.
+    In Juju >=3, the field is a dictionary, but in Juju 2.9 it is a string.
+
+    This patch prevents a crash in Jubilant on the Juju 2.9 format.
+
+    A fix was proposed upstream but not accepted:
+    https://github.com/canonical/jubilant/pull/101
+    """
     _old_from_dict = jubilant.statustypes.AppStatusRelation._from_dict
 
     def _new_from_dict(d: dict[str, Any] | str):

--- a/tests/integration/v2/conftest.py
+++ b/tests/integration/v2/conftest.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any
+
+import jubilant
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def patched_jubilant():
+    _old_from_dict = jubilant.statustypes.AppStatusRelation._from_dict
+
+    def _new_from_dict(d: dict[str, Any] | str):
+        if isinstance(d, str):
+            return jubilant.statustypes.AppStatusRelation(related_app=d)
+        return _old_from_dict(d)
+
+    jubilant.statustypes.AppStatusRelation._from_dict = _new_from_dict

--- a/tests/integration/v2/test_integration_v2.py
+++ b/tests/integration/v2/test_integration_v2.py
@@ -87,7 +87,7 @@ def test_given_charms_deployed_when_relate_then_status_is_active(
 def test_given_charms_deployed_when_relate_then_requirer_received_certs(
     juju: jubilant.Juju,
 ):
-    if juju.cli("version").startswith("2.9"):
+    if juju.cli("version", include_model=False).startswith("2.9"):
         result = json.loads(
             juju.cli(
                 "run-action",
@@ -119,7 +119,7 @@ def test_given_additional_requirer_charm_deployed_when_relate_then_requirer_rece
     juju.cli("relate", new_requirer_app_name, TLS_CERTIFICATES_PROVIDER_APP_NAME)
     _ = juju.wait(jubilant.all_active)
 
-    if juju.cli("version").startswith("2.9"):
+    if juju.cli("version", include_model=False).startswith("2.9"):
         result = json.loads(
             juju.cli(
                 "run-action",

--- a/tests/integration/v2/test_integration_v2.py
+++ b/tests/integration/v2/test_integration_v2.py
@@ -97,16 +97,16 @@ def test_given_charms_deployed_when_relate_then_requirer_received_certs(
                 "--format",
                 "json",
             )
-        )
+        )[f"unit-{TLS_CERTIFICATES_REQUIRER_APP_NAME}-0"]["results"]
     else:
         result = juju.run(
             unit=f"{TLS_CERTIFICATES_REQUIRER_APP_NAME}/0",
             action="get-certificate",
-        )
+        ).results
 
-    assert "ca" in result.results and result.results["ca"] is not None
-    assert "certificate" in result.results and result.results["certificate"] is not None
-    assert "chain" in result.results and result.results["chain"] is not None
+    assert "ca" in result and result["ca"] is not None
+    assert "certificate" in result and result["certificate"] is not None
+    assert "chain" in result and result["chain"] is not None
 
 
 def test_given_additional_requirer_charm_deployed_when_relate_then_requirer_received_certs(
@@ -129,16 +129,16 @@ def test_given_additional_requirer_charm_deployed_when_relate_then_requirer_rece
                 "--format",
                 "json",
             )
-        )
+        )[f"unit-{new_requirer_app_name}-0"]["results"]
     else:
         result = juju.run(
             unit=f"{new_requirer_app_name}/0",
             action="get-certificate",
-        )
+        ).results
 
-    assert "ca" in result.results and result.results["ca"] is not None
-    assert "certificate" in result.results and result.results["certificate"] is not None
-    assert "chain" in result.results and result.results["chain"] is not None
+    assert "ca" in result and result["ca"] is not None
+    assert "certificate" in result and result["certificate"] is not None
+    assert "chain" in result and result["chain"] is not None
 
 
 def test_given_enough_time_passed_then_certificate_expired(

--- a/tests/integration/v2/test_integration_v2.py
+++ b/tests/integration/v2/test_integration_v2.py
@@ -66,7 +66,7 @@ def test_given_charms_packed_when_deploy_charm_then_status_is_blocked(
             .is_blocked
             and status.apps[TLS_CERTIFICATES_PROVIDER_APP_NAME]
             .units[f"{TLS_CERTIFICATES_PROVIDER_APP_NAME}/0"]
-            .is_blocked  # noqa: E501
+            .is_blocked
         ),
         error=jubilant.any_error,
     )
@@ -120,8 +120,12 @@ def test_given_enough_time_passed_then_certificate_expired(
 ):
     juju.wait(
         lambda status: (
-            status.apps[TLS_CERTIFICATES_REQUIRER_APP_NAME].is_blocked
-            and status.apps[TLS_CERTIFICATES_PROVIDER_APP_NAME].is_active
+            status.apps[TLS_CERTIFICATES_REQUIRER_APP_NAME]
+            .units[f"{TLS_CERTIFICATES_REQUIRER_APP_NAME}/0"]
+            .is_blocked
+            and status.apps[TLS_CERTIFICATES_PROVIDER_APP_NAME]
+            .units[f"{TLS_CERTIFICATES_PROVIDER_APP_NAME}/0"]
+            .is_active
         ),
         error=jubilant.any_error,
     )

--- a/tests/integration/v2/test_integration_v2.py
+++ b/tests/integration/v2/test_integration_v2.py
@@ -59,7 +59,17 @@ def test_given_charms_packed_when_deploy_charm_then_status_is_blocked(
 ):
     juju.deploy(requirer_charm, app=TLS_CERTIFICATES_REQUIRER_APP_NAME)
     juju.deploy(provider_charm, app=TLS_CERTIFICATES_PROVIDER_APP_NAME)
-    status = juju.wait(jubilant.all_blocked)
+    status = juju.wait(
+        lambda status: (
+            status.apps[TLS_CERTIFICATES_REQUIRER_APP_NAME]
+            .units[f"{TLS_CERTIFICATES_REQUIRER_APP_NAME}/0"]
+            .is_blocked
+            and status.apps[TLS_CERTIFICATES_PROVIDER_APP_NAME]
+            .units[f"{TLS_CERTIFICATES_PROVIDER_APP_NAME}/0"]
+            .is_blocked  # noqa: E501
+        ),
+        error=jubilant.any_error,
+    )
     assert status.apps[TLS_CERTIFICATES_REQUIRER_APP_NAME].scale == 1
     assert status.apps[TLS_CERTIFICATES_PROVIDER_APP_NAME].scale == 1
 

--- a/tests/integration/v2/test_integration_v2.py
+++ b/tests/integration/v2/test_integration_v2.py
@@ -57,8 +57,8 @@ def test_given_charms_packed_when_deploy_charm_then_status_is_blocked(
     requirer_charm: Path,
     provider_charm: Path,
 ):
-    juju.deploy(requirer_charm, app=TLS_CERTIFICATES_REQUIRER_APP_NAME, base="ubuntu@22.04")
-    juju.deploy(provider_charm, app=TLS_CERTIFICATES_PROVIDER_APP_NAME, base="ubuntu@22.04")
+    juju.deploy(requirer_charm, app=TLS_CERTIFICATES_REQUIRER_APP_NAME)
+    juju.deploy(provider_charm, app=TLS_CERTIFICATES_PROVIDER_APP_NAME)
     status = juju.wait(jubilant.all_blocked)
     assert status.apps[TLS_CERTIFICATES_REQUIRER_APP_NAME].scale == 1
     assert status.apps[TLS_CERTIFICATES_PROVIDER_APP_NAME].scale == 1
@@ -91,7 +91,7 @@ def test_given_additional_requirer_charm_deployed_when_relate_then_requirer_rece
     requirer_charm: Path,
 ):
     new_requirer_app_name = "new-tls-requirer"
-    juju.deploy(requirer_charm, app=new_requirer_app_name, base="ubuntu@22.04")
+    juju.deploy(requirer_charm, app=new_requirer_app_name)
     # Directly calling the CLI because `integrate` is not available on Juju 2
     juju.cli("relate", new_requirer_app_name, TLS_CERTIFICATES_PROVIDER_APP_NAME)
     _ = juju.wait(jubilant.all_active)

--- a/tests/integration/v2/test_integration_v2.py
+++ b/tests/integration/v2/test_integration_v2.py
@@ -132,6 +132,8 @@ def test_given_enough_time_passed_then_certificate_expired(
 
     status = juju.status()
     assert (
-        status.apps[TLS_CERTIFICATES_REQUIRER_APP_NAME].app_status.message
+        status.apps[TLS_CERTIFICATES_REQUIRER_APP_NAME]
+        .units[f"{TLS_CERTIFICATES_REQUIRER_APP_NAME}/0"]
+        .workload_status.message
         == "Told you, now your certificate expired"
     )

--- a/tox.ini
+++ b/tox.ini
@@ -54,34 +54,17 @@ commands =
     coverage run --source={[vars]lib_path} -m pytest {[vars]unit_test_path} -v --tb native -s {posargs}
     coverage report
 
-[testenv:integration-v2-juju-2]
-dependency_groups =
-    test
-    test-juju-2
-description = Run integration tests
-commands =
-    pytest --asyncio-mode=auto -v --tb native {[vars]integration_test_path}/v2 --log-cli-level=INFO -s {posargs}
-
-[testenv:integration-v2-juju-3]
-dependency_groups =
-    test
-    test-juju-3
+[testenv:integration-v2]
 description = Run integration tests
 commands =
     pytest --asyncio-mode=auto -v --tb native {[vars]integration_test_path}/v2 --log-cli-level=INFO -s {posargs}
 
 [testenv:integration-v3]
-dependency_groups =
-    test
-    test-juju-3
 description = Run integration tests
 commands =
     pytest --asyncio-mode=auto -v --tb native {[vars]integration_test_path}/v3 --log-cli-level=INFO -s {posargs}
 
 [testenv:integration-v4]
-dependency_groups =
-    test
-    test-juju-3
 description = Run integration tests
 commands =
     pytest --asyncio-mode=auto -v --tb native {[vars]integration_test_path}/v4 --log-cli-level=INFO -s {posargs}

--- a/uv.lock
+++ b/uv.lock
@@ -1,13 +1,10 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
     "python_full_version < '3.11'",
 ]
-conflicts = [[
-    { package = "tls-certificates-interface", group = "test-juju-2" },
-    { package = "tls-certificates-interface", group = "test-juju-3" },
-]]
 
 [[package]]
 name = "annotated-types"
@@ -353,7 +350,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -478,9 +475,8 @@ version = "0.13.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "decorator" },
-    { name = "ipython", version = "8.35.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "ipython", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
+    { name = "ipython" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/1b/7e07e7b752017f7693a0f4d41c13e5ca29ce8cbcfdcc1fd6c4ad8c0a27a0/ipdb-0.13.13.tar.gz", hash = "sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726", size = 17042 }
 wheels = [
@@ -542,7 +538,17 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393 }
 wheels = [
@@ -601,66 +607,40 @@ wheels = [
 ]
 
 [[package]]
-name = "juju"
-version = "2.9.49.1"
+name = "jubilant"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version < '3.11'",
-]
 dependencies = [
-    { name = "kubernetes", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "macaroonbakery", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "paramiko", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "pyasn1", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "pyrfc3339", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "pyyaml", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "theblues", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "toposort", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "typing-inspect", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "websockets", version = "13.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
+    { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/49/6412759bd2baa4ff348f5414e894de2287d20cb7a516bb7cf12439da925b/juju-2.9.49.1.tar.gz", hash = "sha256:380f6c63e8634645cfb742133a3828b1bf7b3a698fb14aecef031a3d3052b2b2", size = 822723 }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/2e/47b32265d66ab4d77b38954cc4f20ea2835daedbffd789edd70373127c7d/jubilant-0.4.0.tar.gz", hash = "sha256:19ba3dd640236dfba4f31a06926954befe5ef6a50affb780c119488d48589478", size = 22144 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/6a/5dfe681316f1685259cdc248f99feb6414f01dd629e63cf2709456f58782/juju-2.9.49.1-py3-none-any.whl", hash = "sha256:fc5180b64d91046ec38d6412feec30393451cdd4c653a5ae0063148fa818bf55", size = 812820 },
+    { url = "https://files.pythonhosted.org/packages/7b/83/5d6bba578f5d58e38e82533444c4bd9c2a6b3d72d30c5874889b98207001/jubilant-0.4.0-py3-none-any.whl", hash = "sha256:1fce91e3012f00afe4b5db9fabb55d0306353f01564adb4edc84c2885576fbf6", size = 21211 },
 ]
 
 [[package]]
 name = "juju"
 version = "3.6.1.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version < '3.11'",
-]
 dependencies = [
-    { name = "backports-datetime-fromisoformat" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },
     { name = "hvac" },
     { name = "kubernetes" },
     { name = "macaroonbakery" },
     { name = "packaging" },
-    { name = "paramiko", version = "3.5.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "paramiko" },
     { name = "pyasn1" },
+    { name = "pyrfc3339" },
     { name = "pyyaml" },
     { name = "toposort" },
     { name = "typing-extensions" },
     { name = "typing-inspect" },
-    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/32/0816544d9997f66a48a5cd3e799d5f07687da1dc9b5234d44389cbd7b4fc/juju-3.6.1.1.tar.gz", hash = "sha256:2289abd450515b7883f12f06d42f965d31939e711c496cb8713b4b058408e589", size = 305089 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/a0/b3e6e6b79409e384627a79636cd012dd03b5ae103669a868147faf9cd830/juju-3.6.1.1-py3-none-any.whl", hash = "sha256:19ede730130b03cd5a99850f812521c2eb93199771207b50e1edf86e5e47acb2", size = 287124 },
 ]
-
-[[package]]
-name = "jujubundlelib"
-version = "0.5.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/57/57/039c6b7e6a01df336f38549eec0836b61166f012528449e37a0ced4e9ddc/jujubundlelib-0.5.7.tar.gz", hash = "sha256:7e2b1a679faab13c4d56256e31e0cc616d55841abd32598951735bf395ca47e3", size = 30500 }
 
 [[package]]
 name = "kubernetes"
@@ -1152,12 +1132,12 @@ name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
@@ -1183,8 +1163,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ipdb" },
     { name = "jinja2" },
-    { name = "juju", version = "2.9.49.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "juju", version = "3.6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-26-tls-certificates-interface-test-juju-3' or extra != 'group-26-tls-certificates-interface-test-juju-2'" },
+    { name = "juju" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pyyaml" },
@@ -1266,7 +1245,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744 }
 wheels = [
@@ -1447,17 +1426,6 @@ wheels = [
 ]
 
 [[package]]
-name = "theblues"
-version = "0.5.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jujubundlelib", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "macaroonbakery", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "requests", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/44/09471b2abf1cc22a427a8d49e4cfa9049bc18ea2c99d318faffc37b367a3/theblues-0.5.2.tar.gz", hash = "sha256:a9aded6b151c67d83eb9adcbcb38640872d9f29db985053259afd2fc012e5ed9", size = 18826 }
-
-[[package]]
 name = "tls-certificates-interface"
 version = "0.1.0"
 source = { virtual = "." }
@@ -1477,17 +1445,12 @@ dev = [
 ]
 test = [
     { name = "coverage", extra = ["toml"] },
+    { name = "jubilant" },
+    { name = "juju" },
     { name = "ops", extra = ["testing"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-operator" },
-]
-test-juju-2 = [
-    { name = "juju", version = "2.9.49.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "websockets", version = "13.1", source = { registry = "https://pypi.org/simple" } },
-]
-test-juju-3 = [
-    { name = "juju", version = "3.6.1.1", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [package.metadata]
@@ -1507,16 +1470,13 @@ dev = [
 ]
 test = [
     { name = "coverage", extras = ["toml"] },
+    { name = "jubilant" },
+    { name = "juju", specifier = ">3" },
     { name = "ops", extras = ["testing"] },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = "==0.21.2" },
     { name = "pytest-operator" },
 ]
-test-juju-2 = [
-    { name = "juju", specifier = "==2.9.49.1" },
-    { name = "websockets", specifier = "==13.1" },
-]
-test-juju-3 = [{ name = "juju", specifier = ">3" }]
 
 [[package]]
 name = "tomli"
@@ -1638,76 +1598,9 @@ wheels = [
 
 [[package]]
 name = "websockets"
-version = "13.1"
+version = "14.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version < '3.11'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/73/9223dbc7be3dcaf2a7bbf756c351ec8da04b1fa573edaf545b95f6b0c7fd/websockets-13.1.tar.gz", hash = "sha256:a3b3366087c1bc0a2795111edcadddb8b3b59509d5db5d7ea3fdd69f954a8878", size = 158549 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/94/d15dbfc6a5eb636dbc754303fba18208f2e88cf97e733e1d64fb9cb5c89e/websockets-13.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f48c749857f8fb598fb890a75f540e3221d0976ed0bf879cf3c7eef34151acee", size = 157815 },
-    { url = "https://files.pythonhosted.org/packages/30/02/c04af33f4663945a26f5e8cf561eb140c35452b50af47a83c3fbcfe62ae1/websockets-13.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c7e72ce6bda6fb9409cc1e8164dd41d7c91466fb599eb047cfda72fe758a34a7", size = 155466 },
-    { url = "https://files.pythonhosted.org/packages/35/e8/719f08d12303ea643655e52d9e9851b2dadbb1991d4926d9ce8862efa2f5/websockets-13.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f779498eeec470295a2b1a5d97aa1bc9814ecd25e1eb637bd9d1c73a327387f6", size = 155716 },
-    { url = "https://files.pythonhosted.org/packages/91/e1/14963ae0252a8925f7434065d25dcd4701d5e281a0b4b460a3b5963d2594/websockets-13.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4676df3fe46956fbb0437d8800cd5f2b6d41143b6e7e842e60554398432cf29b", size = 164806 },
-    { url = "https://files.pythonhosted.org/packages/ec/fa/ab28441bae5e682a0f7ddf3d03440c0c352f930da419301f4a717f675ef3/websockets-13.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7affedeb43a70351bb811dadf49493c9cfd1ed94c9c70095fd177e9cc1541fa", size = 163810 },
-    { url = "https://files.pythonhosted.org/packages/44/77/dea187bd9d16d4b91566a2832be31f99a40d0f5bfa55eeb638eb2c3bc33d/websockets-13.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1971e62d2caa443e57588e1d82d15f663b29ff9dfe7446d9964a4b6f12c1e700", size = 164125 },
-    { url = "https://files.pythonhosted.org/packages/cf/d9/3af14544e83f1437eb684b399e6ba0fa769438e869bf5d83d74bc197fae8/websockets-13.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5f2e75431f8dc4a47f31565a6e1355fb4f2ecaa99d6b89737527ea917066e26c", size = 164532 },
-    { url = "https://files.pythonhosted.org/packages/1c/8a/6d332eabe7d59dfefe4b8ba6f46c8c5fabb15b71c8a8bc3d2b65de19a7b6/websockets-13.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:58cf7e75dbf7e566088b07e36ea2e3e2bd5676e22216e4cad108d4df4a7402a0", size = 163948 },
-    { url = "https://files.pythonhosted.org/packages/1a/91/a0aeadbaf3017467a1ee03f8fb67accdae233fe2d5ad4b038c0a84e357b0/websockets-13.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c90d6dec6be2c7d03378a574de87af9b1efea77d0c52a8301dd831ece938452f", size = 163898 },
-    { url = "https://files.pythonhosted.org/packages/71/31/a90fb47c63e0ae605be914b0b969d7c6e6ffe2038cd744798e4b3fbce53b/websockets-13.1-cp310-cp310-win32.whl", hash = "sha256:730f42125ccb14602f455155084f978bd9e8e57e89b569b4d7f0f0c17a448ffe", size = 158706 },
-    { url = "https://files.pythonhosted.org/packages/93/ca/9540a9ba80da04dc7f36d790c30cae4252589dbd52ccdc92e75b0be22437/websockets-13.1-cp310-cp310-win_amd64.whl", hash = "sha256:5993260f483d05a9737073be197371940c01b257cc45ae3f1d5d7adb371b266a", size = 159141 },
-    { url = "https://files.pythonhosted.org/packages/b2/f0/cf0b8a30d86b49e267ac84addbebbc7a48a6e7bb7c19db80f62411452311/websockets-13.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:61fc0dfcda609cda0fc9fe7977694c0c59cf9d749fbb17f4e9483929e3c48a19", size = 157813 },
-    { url = "https://files.pythonhosted.org/packages/bf/e7/22285852502e33071a8cf0ac814f8988480ec6db4754e067b8b9d0e92498/websockets-13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ceec59f59d092c5007e815def4ebb80c2de330e9588e101cf8bd94c143ec78a5", size = 155469 },
-    { url = "https://files.pythonhosted.org/packages/68/d4/c8c7c1e5b40ee03c5cc235955b0fb1ec90e7e37685a5f69229ad4708dcde/websockets-13.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c1dca61c6db1166c48b95198c0b7d9c990b30c756fc2923cc66f68d17dc558fd", size = 155717 },
-    { url = "https://files.pythonhosted.org/packages/c9/e4/c50999b9b848b1332b07c7fd8886179ac395cb766fda62725d1539e7bc6c/websockets-13.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:308e20f22c2c77f3f39caca508e765f8725020b84aa963474e18c59accbf4c02", size = 165379 },
-    { url = "https://files.pythonhosted.org/packages/bc/49/4a4ad8c072f18fd79ab127650e47b160571aacfc30b110ee305ba25fffc9/websockets-13.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d516c325e6540e8a57b94abefc3459d7dab8ce52ac75c96cad5549e187e3a7", size = 164376 },
-    { url = "https://files.pythonhosted.org/packages/af/9b/8c06d425a1d5a74fd764dd793edd02be18cf6fc3b1ccd1f29244ba132dc0/websockets-13.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87c6e35319b46b99e168eb98472d6c7d8634ee37750d7693656dc766395df096", size = 164753 },
-    { url = "https://files.pythonhosted.org/packages/d5/5b/0acb5815095ff800b579ffc38b13ab1b915b317915023748812d24e0c1ac/websockets-13.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5f9fee94ebafbc3117c30be1844ed01a3b177bb6e39088bc6b2fa1dc15572084", size = 165051 },
-    { url = "https://files.pythonhosted.org/packages/30/93/c3891c20114eacb1af09dedfcc620c65c397f4fd80a7009cd12d9457f7f5/websockets-13.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7c1e90228c2f5cdde263253fa5db63e6653f1c00e7ec64108065a0b9713fa1b3", size = 164489 },
-    { url = "https://files.pythonhosted.org/packages/28/09/af9e19885539759efa2e2cd29b8b3f9eecef7ecefea40d46612f12138b36/websockets-13.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6548f29b0e401eea2b967b2fdc1c7c7b5ebb3eeb470ed23a54cd45ef078a0db9", size = 164438 },
-    { url = "https://files.pythonhosted.org/packages/b6/08/6f38b8e625b3d93de731f1d248cc1493327f16cb45b9645b3e791782cff0/websockets-13.1-cp311-cp311-win32.whl", hash = "sha256:c11d4d16e133f6df8916cc5b7e3e96ee4c44c936717d684a94f48f82edb7c92f", size = 158710 },
-    { url = "https://files.pythonhosted.org/packages/fb/39/ec8832ecb9bb04a8d318149005ed8cee0ba4e0205835da99e0aa497a091f/websockets-13.1-cp311-cp311-win_amd64.whl", hash = "sha256:d04f13a1d75cb2b8382bdc16ae6fa58c97337253826dfe136195b7f89f661557", size = 159137 },
-    { url = "https://files.pythonhosted.org/packages/df/46/c426282f543b3c0296cf964aa5a7bb17e984f58dde23460c3d39b3148fcf/websockets-13.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:9d75baf00138f80b48f1eac72ad1535aac0b6461265a0bcad391fc5aba875cfc", size = 157821 },
-    { url = "https://files.pythonhosted.org/packages/aa/85/22529867010baac258da7c45848f9415e6cf37fef00a43856627806ffd04/websockets-13.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:9b6f347deb3dcfbfde1c20baa21c2ac0751afaa73e64e5b693bb2b848efeaa49", size = 155480 },
-    { url = "https://files.pythonhosted.org/packages/29/2c/bdb339bfbde0119a6e84af43ebf6275278698a2241c2719afc0d8b0bdbf2/websockets-13.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de58647e3f9c42f13f90ac7e5f58900c80a39019848c5547bc691693098ae1bd", size = 155715 },
-    { url = "https://files.pythonhosted.org/packages/9f/d0/8612029ea04c5c22bf7af2fd3d63876c4eaeef9b97e86c11972a43aa0e6c/websockets-13.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1b54689e38d1279a51d11e3467dd2f3a50f5f2e879012ce8f2d6943f00e83f0", size = 165647 },
-    { url = "https://files.pythonhosted.org/packages/56/04/1681ed516fa19ca9083f26d3f3a302257e0911ba75009533ed60fbb7b8d1/websockets-13.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf1781ef73c073e6b0f90af841aaf98501f975d306bbf6221683dd594ccc52b6", size = 164592 },
-    { url = "https://files.pythonhosted.org/packages/38/6f/a96417a49c0ed132bb6087e8e39a37db851c70974f5c724a4b2a70066996/websockets-13.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d23b88b9388ed85c6faf0e74d8dec4f4d3baf3ecf20a65a47b836d56260d4b9", size = 165012 },
-    { url = "https://files.pythonhosted.org/packages/40/8b/fccf294919a1b37d190e86042e1a907b8f66cff2b61e9befdbce03783e25/websockets-13.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3c78383585f47ccb0fcf186dcb8a43f5438bd7d8f47d69e0b56f71bf431a0a68", size = 165311 },
-    { url = "https://files.pythonhosted.org/packages/c1/61/f8615cf7ce5fe538476ab6b4defff52beb7262ff8a73d5ef386322d9761d/websockets-13.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d6d300f8ec35c24025ceb9b9019ae9040c1ab2f01cddc2bcc0b518af31c75c14", size = 164692 },
-    { url = "https://files.pythonhosted.org/packages/5c/f1/a29dd6046d3a722d26f182b783a7997d25298873a14028c4760347974ea3/websockets-13.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a9dcaf8b0cc72a392760bb8755922c03e17a5a54e08cca58e8b74f6902b433cf", size = 164686 },
-    { url = "https://files.pythonhosted.org/packages/0f/99/ab1cdb282f7e595391226f03f9b498f52109d25a2ba03832e21614967dfa/websockets-13.1-cp312-cp312-win32.whl", hash = "sha256:2f85cf4f2a1ba8f602298a853cec8526c2ca42a9a4b947ec236eaedb8f2dc80c", size = 158712 },
-    { url = "https://files.pythonhosted.org/packages/46/93/e19160db48b5581feac8468330aa11b7292880a94a37d7030478596cc14e/websockets-13.1-cp312-cp312-win_amd64.whl", hash = "sha256:38377f8b0cdeee97c552d20cf1865695fcd56aba155ad1b4ca8779a5b6ef4ac3", size = 159145 },
-    { url = "https://files.pythonhosted.org/packages/51/20/2b99ca918e1cbd33c53db2cace5f0c0cd8296fc77558e1908799c712e1cd/websockets-13.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a9ab1e71d3d2e54a0aa646ab6d4eebfaa5f416fe78dfe4da2839525dc5d765c6", size = 157828 },
-    { url = "https://files.pythonhosted.org/packages/b8/47/0932a71d3d9c0e9483174f60713c84cee58d62839a143f21a2bcdbd2d205/websockets-13.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b9d7439d7fab4dce00570bb906875734df13d9faa4b48e261c440a5fec6d9708", size = 155487 },
-    { url = "https://files.pythonhosted.org/packages/a9/60/f1711eb59ac7a6c5e98e5637fef5302f45b6f76a2c9d64fd83bbb341377a/websockets-13.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:327b74e915cf13c5931334c61e1a41040e365d380f812513a255aa804b183418", size = 155721 },
-    { url = "https://files.pythonhosted.org/packages/6a/e6/ba9a8db7f9d9b0e5f829cf626ff32677f39824968317223605a6b419d445/websockets-13.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:325b1ccdbf5e5725fdcb1b0e9ad4d2545056479d0eee392c291c1bf76206435a", size = 165609 },
-    { url = "https://files.pythonhosted.org/packages/c1/22/4ec80f1b9c27a0aebd84ccd857252eda8418ab9681eb571b37ca4c5e1305/websockets-13.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:346bee67a65f189e0e33f520f253d5147ab76ae42493804319b5716e46dddf0f", size = 164556 },
-    { url = "https://files.pythonhosted.org/packages/27/ac/35f423cb6bb15600438db80755609d27eda36d4c0b3c9d745ea12766c45e/websockets-13.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91a0fa841646320ec0d3accdff5b757b06e2e5c86ba32af2e0815c96c7a603c5", size = 164993 },
-    { url = "https://files.pythonhosted.org/packages/31/4e/98db4fd267f8be9e52e86b6ee4e9aa7c42b83452ea0ea0672f176224b977/websockets-13.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:18503d2c5f3943e93819238bf20df71982d193f73dcecd26c94514f417f6b135", size = 165360 },
-    { url = "https://files.pythonhosted.org/packages/3f/15/3f0de7cda70ffc94b7e7024544072bc5b26e2c1eb36545291abb755d8cdb/websockets-13.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9cd1af7e18e5221d2878378fbc287a14cd527fdd5939ed56a18df8a31136bb2", size = 164745 },
-    { url = "https://files.pythonhosted.org/packages/a1/6e/66b6b756aebbd680b934c8bdbb6dcb9ce45aad72cde5f8a7208dbb00dd36/websockets-13.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:70c5be9f416aa72aab7a2a76c90ae0a4fe2755c1816c153c1a2bcc3333ce4ce6", size = 164732 },
-    { url = "https://files.pythonhosted.org/packages/35/c6/12e3aab52c11aeb289e3dbbc05929e7a9d90d7a9173958477d3ef4f8ce2d/websockets-13.1-cp313-cp313-win32.whl", hash = "sha256:624459daabeb310d3815b276c1adef475b3e6804abaf2d9d2c061c319f7f187d", size = 158709 },
-    { url = "https://files.pythonhosted.org/packages/41/d8/63d6194aae711d7263df4498200c690a9c39fb437ede10f3e157a6343e0d/websockets-13.1-cp313-cp313-win_amd64.whl", hash = "sha256:c518e84bb59c2baae725accd355c8dc517b4a3ed8db88b4bc93c78dae2974bf2", size = 159144 },
-    { url = "https://files.pythonhosted.org/packages/2d/75/6da22cb3ad5b8c606963f9a5f9f88656256fecc29d420b4b2bf9e0c7d56f/websockets-13.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5dd6da9bec02735931fccec99d97c29f47cc61f644264eb995ad6c0c27667238", size = 155499 },
-    { url = "https://files.pythonhosted.org/packages/c0/ba/22833d58629088fcb2ccccedfae725ac0bbcd713319629e97125b52ac681/websockets-13.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:2510c09d8e8df777177ee3d40cd35450dc169a81e747455cc4197e63f7e7bfe5", size = 155737 },
-    { url = "https://files.pythonhosted.org/packages/95/54/61684fe22bdb831e9e1843d972adadf359cf04ab8613285282baea6a24bb/websockets-13.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1c3cf67185543730888b20682fb186fc8d0fa6f07ccc3ef4390831ab4b388d9", size = 157095 },
-    { url = "https://files.pythonhosted.org/packages/fc/f5/6652fb82440813822022a9301a30afde85e5ff3fb2aebb77f34aabe2b4e8/websockets-13.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bcc03c8b72267e97b49149e4863d57c2d77f13fae12066622dc78fe322490fe6", size = 156701 },
-    { url = "https://files.pythonhosted.org/packages/67/33/ae82a7b860fa8a08aba68818bdf7ff61f04598aa5ab96df4cd5a3e418ca4/websockets-13.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:004280a140f220c812e65f36944a9ca92d766b6cc4560be652a0a3883a79ed8a", size = 156654 },
-    { url = "https://files.pythonhosted.org/packages/63/0b/a1b528d36934f833e20f6da1032b995bf093d55cb416b9f2266f229fb237/websockets-13.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:e2620453c075abeb0daa949a292e19f56de518988e079c36478bacf9546ced23", size = 159192 },
-    { url = "https://files.pythonhosted.org/packages/56/27/96a5cd2626d11c8280656c6c71d8ab50fe006490ef9971ccd154e0c42cd2/websockets-13.1-py3-none-any.whl", hash = "sha256:a9a396a6ad26130cdae92ae10c36af09d9bfe6cafe69670fd3b6da9b07b4044f", size = 152134 },
-]
-
-[[package]]
-name = "websockets"
-version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version < '3.11'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016 }
+sdist = { url = "https://files.pythonhosted.org/packages/94/54/8359678c726243d19fae38ca14a334e740782336c9f19700858c4eb64a1e/websockets-14.2.tar.gz", hash = "sha256:5059ed9c54945efb321f097084b4c7e52c246f2c869815876a69d1efc4ad6eb5", size = 164394 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423 },
     { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080 },

--- a/uv.lock
+++ b/uv.lock
@@ -475,7 +475,8 @@ version = "0.13.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "decorator" },
-    { name = "ipython" },
+    { name = "ipython", version = "8.35.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/1b/7e07e7b752017f7693a0f4d41c13e5ca29ce8cbcfdcc1fd6c4ad8c0a27a0/ipdb-0.13.13.tar.gz", hash = "sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726", size = 17042 }
@@ -491,17 +492,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.11' and extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3') or (sys_platform != 'win32' and extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "decorator", marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "jedi", marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "pexpect", marker = "(python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version >= '3.11' and extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3') or (sys_platform == 'emscripten' and extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3') or (sys_platform == 'win32' and extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "pygments", marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "stack-data", marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "traitlets", marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/77/7d1501e8b539b179936e0d5969b578ed23887be0ab8c63e0120b825bda3e/ipython-8.35.0.tar.gz", hash = "sha256:d200b7d93c3f5883fc36ab9ce28a18249c7706e51347681f80a0aef9895f2520", size = 5605027 }
 wheels = [
@@ -516,17 +517,17 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "(python_full_version >= '3.11' and sys_platform == 'win32') or (python_full_version < '3.11' and extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3') or (sys_platform != 'win32' and extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "decorator", marker = "python_full_version >= '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "jedi", marker = "python_full_version >= '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "pexpect", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version < '3.11' and extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3') or (sys_platform == 'emscripten' and extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3') or (sys_platform == 'win32' and extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "stack-data", marker = "python_full_version >= '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "traitlets", marker = "python_full_version >= '3.11' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*' or (extra == 'group-26-tls-certificates-interface-test-juju-2' and extra == 'group-26-tls-certificates-interface-test-juju-3')" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/70/9a/6b8984bedc990f3a4aa40ba8436dea27e23d26a64527de7c2e5e12e76841/ipython-9.1.0.tar.gz", hash = "sha256:a47e13a5e05e02f3b8e1e7a0f9db372199fe8c3763532fe7a1e0379e4e135f16", size = 4373688 }
 wheels = [
@@ -538,17 +539,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393 }
 wheels = [
@@ -596,26 +587,26 @@ wheels = [
 
 [[package]]
 name = "jsonschema-specifications"
-version = "2024.10.1"
+version = "2025.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "referencing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/db/58f950c996c793472e336ff3655b13fbcf1e3b359dcf52dcf3ed3b52c352/jsonschema_specifications-2024.10.1.tar.gz", hash = "sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272", size = 15561 }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/ce/46fbd9c8119cfc3581ee5643ea49464d168028cfb5caff5fc0596d0cf914/jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608", size = 15513 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/0f/8910b19ac0670a0f80ce1008e5e751c4a57e14d2c4c13a482aa6079fa9d6/jsonschema_specifications-2024.10.1-py3-none-any.whl", hash = "sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf", size = 18459 },
+    { url = "https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af", size = 18437 },
 ]
 
 [[package]]
 name = "jubilant"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/2e/47b32265d66ab4d77b38954cc4f20ea2835daedbffd789edd70373127c7d/jubilant-0.4.0.tar.gz", hash = "sha256:19ba3dd640236dfba4f31a06926954befe5ef6a50affb780c119488d48589478", size = 22144 }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/f1/41362d3bfb5c2c44f9bdf9a900e5899f3b9da40fa6e7b88be821dd619e27/jubilant-0.4.1.tar.gz", hash = "sha256:0acec84d6ebe48f305bf3acc484347fb2c25e9aa7451019f7a44893f95c93779", size = 22545 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/83/5d6bba578f5d58e38e82533444c4bd9c2a6b3d72d30c5874889b98207001/jubilant-0.4.0-py3-none-any.whl", hash = "sha256:1fce91e3012f00afe4b5db9fabb55d0306353f01564adb4edc84c2885576fbf6", size = 21211 },
+    { url = "https://files.pythonhosted.org/packages/8e/c1/c2cc03d2c0420353659388f3e646a09ea54c27357d79c6bf528bf71793ff/jubilant-0.4.1-py3-none-any.whl", hash = "sha256:d3fa4bd4bd9de28e41c81010ea0fc1cc3be98be744149a71fd906a613ea177ea", size = 21627 },
 ]
 
 [[package]]
@@ -623,6 +614,7 @@ name = "juju"
 version = "3.6.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "backports-datetime-fromisoformat" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },
     { name = "hvac" },
     { name = "kubernetes" },
@@ -630,7 +622,6 @@ dependencies = [
     { name = "packaging" },
     { name = "paramiko" },
     { name = "pyasn1" },
-    { name = "pyrfc3339" },
     { name = "pyyaml" },
     { name = "toposort" },
     { name = "typing-extensions" },
@@ -819,31 +810,8 @@ wheels = [
 
 [[package]]
 name = "paramiko"
-version = "2.12.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "bcrypt", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "cryptography", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "pynacl", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-    { name = "six", marker = "extra == 'group-26-tls-certificates-interface-test-juju-2'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/75/e78ddbe671a4a59514b59bc6a321263118e4ac3fe88175dd784d1a47a00f/paramiko-2.12.0.tar.gz", hash = "sha256:376885c05c5d6aa6e1f4608aac2a6b5b0548b1add40274477324605903d9cd49", size = 1076369 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/6d/95777fd66507106d2f8f81d005255c237187951644f85a5bd0baeec8a88f/paramiko-2.12.0-py2.py3-none-any.whl", hash = "sha256:b2df1a6325f6996ef55a8789d0462f5b502ea83b3c990cbb5bbe57345c6812c4", size = 213084 },
-]
-
-[[package]]
-name = "paramiko"
 version = "3.5.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version < '3.11'",
-]
 dependencies = [
     { name = "bcrypt" },
     { name = "cryptography" },
@@ -1470,7 +1438,7 @@ dev = [
 ]
 test = [
     { name = "coverage", extras = ["toml"] },
-    { name = "jubilant" },
+    { name = "jubilant", specifier = "==0.4.1" },
     { name = "juju", specifier = ">3" },
     { name = "ops", extras = ["testing"] },
     { name = "pytest" },
@@ -1598,9 +1566,9 @@ wheels = [
 
 [[package]]
 name = "websockets"
-version = "14.2"
+version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/54/8359678c726243d19fae38ca14a334e740782336c9f19700858c4eb64a1e/websockets-14.2.tar.gz", hash = "sha256:5059ed9c54945efb321f097084b4c7e52c246f2c869815876a69d1efc4ad6eb5", size = 164394 }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423 },
     { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080 },


### PR DESCRIPTION
# Description

Use `jubilant` instead of `pytest-operator` for the integration tests of v2.

This is done now to remove the conflicting dependencies on `juju==2.9.49.1` and `juju>3` that break Renovate. This will help ensure that regular updates on our dependencies keep happening automatically.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
