### PR TITLE
feat: Adds sync public function to enable requirer charms to run _configure

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -52,7 +52,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 19
+LIBPATCH = 20
 
 PYDEPS = [
     "cryptography>=43.0.0",
@@ -1232,7 +1232,7 @@ class TLSCertificatesRequiresV4(Object):
         for event in refresh_events:
             self.framework.observe(event, self._configure)
 
-    def _configure(self, _: EventBase):
+    def _configure(self, _: Optional[EventBase] = None):
         """Handle TLS Certificates Relation Data.
 
         This method is called during any TLS relation event.
@@ -1285,6 +1285,14 @@ class TLSCertificatesRequiresV4(Object):
         csr = CertificateSigningRequest.from_string(csr_str)
         self._renew_certificate_request(csr)
         event.secret.remove_all_revisions()
+
+    def sync(self) -> None:
+        """Sync TLS Certificates Relation Data.
+
+        This method allows the requirer to sync the TLS certificates relation data
+        without waiting for the refresh events to be triggered.
+        """
+        self._configure()
 
     def renew_certificate(self, certificate: ProviderCertificate) -> None:
         """Request the renewal of the provided certificate."""


### PR DESCRIPTION
# Description

Fixes #355 

Currently the requirer charm relies on a refresh event to update the certificate request attributes. In this PR we provide a public `sync` function that will allow the requirer to call it and directly run `_configure` so csrs are synced without waiting for the refresh event.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
