### PR TITLE
fix: Provider crash on relation departed

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -52,7 +52,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 20
+LIBPATCH = 21
 
 PYDEPS = [
     "cryptography>=43.0.0",
@@ -1804,7 +1804,7 @@ class TLSCertificatesProvidesV4(Object):
         self, relation: Relation, unit_or_app: Union[Application, Unit]
     ) -> List[RequirerCertificateRequest]:
         try:
-            requirer_relation_data = _RequirerData.load(relation.data[unit_or_app])
+            requirer_relation_data = _RequirerData.load(relation.data.get(unit_or_app, {}))
         except DataValidationError:
             logger.debug("Invalid requirer relation data for %s", unit_or_app.name)
             return []


### PR DESCRIPTION
# Description

On relation departed, it is possible for the relation to have a list of units but no entry for that unit in the relation data. If a provider tried to load the relation data in that case it would crash with a `KeyError`.

This change does not include unit tests, because `ops[testing]` does not seem to allow creating a `Relation` in that particular case.

I instead tested it manually with `manual-tls-certificates`, where I initially found the problem.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
