### PR TITLE
fix(DPE-8338): Use relative renewal time when updating cert secret

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -52,7 +52,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 21
+LIBPATCH = 22
 
 PYDEPS = [
     "cryptography>=43.0.0",


### PR DESCRIPTION
# Description
Fixes #363 

This seems to be a race condition situation. The SSC provider potentially can update the certificate before the requirer handles the revoked status and issues a secret removed event. This prevents the requirer from updating the relative renewal expiry time of the secret only done when the secret doesn't exist in the previous logic. 


## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
