### PR TITLE
feat: Add support for additional critical extensions to generate CSR

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -77,7 +77,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 25
+LIBPATCH = 26
 
 PYDEPS = [
     "cryptography>=43.0.0",
@@ -987,6 +987,11 @@ class CertificateSigningRequest:
             csr_builder = csr_builder.add_extension(
                 x509.SubjectAlternativeName(set(_sans)), critical=False
             )
+
+        if attributes.additional_critical_extensions:
+            for extension in attributes.additional_critical_extensions:
+                csr_builder = csr_builder.add_extension(extension, critical=True)
+
         signed_certificate_request = csr_builder.sign(signing_key, hashes.SHA256())
         return cls(x509_object=signed_certificate_request)
 
@@ -1008,6 +1013,7 @@ class CertificateRequestAttributes:
         locality_name: Optional[str] = None,
         is_ca: bool = False,
         add_unique_id_to_subject_name: bool = True,
+        additional_critical_extensions: Optional[List[x509.ExtensionType]] = None,
     ):
         if not common_name and not sans_dns and not sans_ip and not sans_oid:
             raise ValueError(
@@ -1025,6 +1031,7 @@ class CertificateRequestAttributes:
         self._locality_name = locality_name
         self._is_ca = is_ca
         self._add_unique_id_to_subject_name = add_unique_id_to_subject_name
+        self._additional_critical_extensions = (additional_critical_extensions or [])[:]
 
     @property
     def common_name(self) -> str:
@@ -1087,6 +1094,11 @@ class CertificateRequestAttributes:
         """Return whether to add a unique identifier to the subject name."""
         return self._add_unique_id_to_subject_name
 
+    @property
+    def additional_critical_extensions(self) -> List[x509.ExtensionType]:
+        """Return the list of additional critical extensions."""
+        return self._additional_critical_extensions
+
     @classmethod
     def from_csr(
         cls, csr: CertificateSigningRequest, is_ca: bool
@@ -1100,6 +1112,8 @@ class CertificateRequestAttributes:
         Returns:
             CertificateRequestAttributes: The extracted attributes.
         """
+        extensions = x509.load_pem_x509_csr(str(csr).encode()).extensions
+        critical_extensions = [ext.value for ext in extensions if ext.critical]
         return cls(
             common_name=csr.common_name,
             sans_dns=csr.sans_dns,
@@ -1113,6 +1127,7 @@ class CertificateRequestAttributes:
             locality_name=csr.locality_name,
             is_ca=is_ca,
             add_unique_id_to_subject_name=csr.has_unique_identifier,
+            additional_critical_extensions=critical_extensions,
         )
 
     def __eq__(self, other: object) -> bool:
@@ -1132,6 +1147,7 @@ class CertificateRequestAttributes:
             and self.locality_name == other.locality_name
             and self.is_ca == other.is_ca
             and self.add_unique_id_to_subject_name == other.add_unique_id_to_subject_name
+            and self.additional_critical_extensions == other.additional_critical_extensions
         )
 
     def is_valid(self) -> bool:


### PR DESCRIPTION
# Description

Add provision to provide additional critical extensions to generate CSR. CertificateRequestsAttribute has a new argument to add additional critical extensions which charms can make use of.

Fixes: #402

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
